### PR TITLE
1.4 catchup

### DIFF
--- a/ExampleMod/Common/Players/ExampleAccessorySlot.cs
+++ b/ExampleMod/Common/Players/ExampleAccessorySlot.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Players
+{
+	public class ExampleModAccessorySlot1 : ModAccessorySlot
+	{
+		// If the class is empty, everything will default to a basic vanilla slot.
+	}
+
+	public class ExampleCustomLocationAndTextureSlot : ModAccessorySlot
+	{
+		// We will place the slot to be at the center of the map, making the decision not to follow the internal UI handling
+		public override Vector2? CustomLocation => new Vector2(Main.screenWidth / 2, 3 * Main.screenHeight / 4);
+
+		// We will disable drawing the vanity slot
+		public override bool DrawVanitySlot => false;
+
+		//     We will use our 'custom' textures
+		// Background Textures -> In general, you can use most of the existing vanilla ones to get different colours
+		public override string VanityBackgroundTexture => "Terraria/Images/Inventory_Back14"; // yellow
+		public override string FunctionalBackgroundTexture => "Terraria/Images/Inventory_Back7"; // pale blue
+
+		// Icon textures. Expects 32x32 images if you want it to look proper. 
+		public override string VanityTexture => "Terraria/Images/Item_" + ItemID.PiggyBank; // The piggy bank is 16x24, so we expect it to look funny. Is a fun funny tho :)
+
+		// We will keep it hidden most of the time so that it isn't an intrusive example
+		public override bool IsHidden() {
+			return IsEmpty; // Only show when it contains an item, items can end up in functional slots via quick swap (right click accessory) 
+		}
+	}
+
+	public class ExampleModWingSlot : ModAccessorySlot
+	{
+		public override bool CanAcceptItem(Item checkItem, AccessorySlotType context) {
+			if (checkItem.wingSlot > 0) // if is Wing, then can go in slot
+				return true;
+
+			return false; // Otherwise nothing in slot
+		}
+
+		// Designates our slot to be a priority for putting wings in to. NOTE: use ItemLoader.CanEquipAccessory if aiming for restricting other slots from having wings!
+		public override bool ModifyDefaultSwapSlot(Item item, int accSlotToSwapTo) {
+			if (item.wingSlot > 0) // If is Wing, then we want to prioritize it to go in to our slot. 
+				return true;
+
+			return false;
+		}
+
+		public override bool IsEnabled() {
+			if (Player.armor[0].headSlot >= 0) // if player is wearing a helmet, because flight safety
+				return true; // Then can use Slot
+
+			return false; // Can't use slot
+		}
+
+		// Overrides the default behaviour where a disabled accessory slot will allow retrieve items if it contains items
+		public override bool IsVisibleWhenNotEnabled() {
+			return false; // We set to false to just not display if not Enabled. NOTE: this does not affect behavour when mod is unloaded!
+		}
+
+		// Icon textures. Expects 32x32 images if you want it to look proper. 
+		public override string FunctionalTexture => "Terraria/Images/Item_" + ItemID.CreativeWings;
+
+		// Can be used to modify stuff while the Mouse is hovering over the slot.
+		public override void OnMouseHover(AccessorySlotType context) {
+			// We will modify the hover text while an item is not in the slot, so that it says "Wings".
+			switch (context) {
+				case AccessorySlotType.FunctionalSlot:
+				case AccessorySlotType.VanitySlot:
+					Main.hoverItemName = "Wings";
+					break;
+				case AccessorySlotType.DyeSlot:
+					Main.hoverItemName = "Wings Dye";
+					break;
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/GameContent/Achievements/AchievementsHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Achievements/AchievementsHelper.cs.patch
@@ -1,0 +1,17 @@
+--- src/Terraria/Terraria/GameContent/Achievements/AchievementsHelper.cs
++++ src/tModLoader/Terraria/GameContent/Achievements/AchievementsHelper.cs
+@@ -1,3 +_,5 @@
++using System.Linq;
++
+ namespace Terraria.GameContent.Achievements
+ {
+ 	public class AchievementsHelper
+@@ -164,7 +_,7 @@
+ 			if (context == 17)
+ 				Main.Achievements.GetCondition("THE_CAVALRY", "Equip").Complete();
+ 
+-			if ((context == 10 || context == 11) && item.wingSlot > 0)
++			if (new int[4] { 10, 11, -10, 11 }.Contains(context) && item.wingSlot > 0)
+ 				Main.Achievements.GetCondition("HEAD_IN_THE_CLOUDS", "Equip").Complete();
+ 
+ 			if (context == 8 && player.armor[0].stack > 0 && player.armor[1].stack > 0 && player.armor[2].stack > 0)

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs.patch
@@ -1,0 +1,20 @@
+--- src/Terraria/Terraria/GameContent/UI/Elements/UICharacter.cs
++++ src/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs
+@@ -30,6 +_,8 @@
+ 		}
+ 
+ 		public override void Update(GameTime gameTime) {
++			using var _currentPlr = new Main.CurrentPlayerOverride(_player);
++
+ 			_player.ResetEffects();
+ 			_player.ResetVisibleAccessories();
+ 			_player.UpdateMiscCounter();
+@@ -53,6 +_,8 @@
+ 		}
+ 
+ 		protected override void DrawSelf(SpriteBatch spriteBatch) {
++			using var _currentPlr = new Main.CurrentPlayerOverride(_player);
++
+ 			CalculatedStyle dimensions = GetDimensions();
+ 			if (_drawsBackPanel)
+ 				spriteBatch.Draw(_texture.Value, dimensions.Position(), Color.White);

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
@@ -9,3 +9,12 @@
  	{
  		private float _viewPosition;
  		private float _viewSize = 1f;
+@@ -60,7 +_,7 @@
+ 			return new Rectangle((int)innerDimensions.X, (int)(innerDimensions.Y + innerDimensions.Height * (_viewPosition / _maxViewSize)) - 3, 20, (int)(innerDimensions.Height * (_viewSize / _maxViewSize)) + 7);
+ 		}
+ 
+-		private void DrawBar(SpriteBatch spriteBatch, Texture2D texture, Rectangle dimensions, Color color) {
++		internal void DrawBar(SpriteBatch spriteBatch, Texture2D texture, Rectangle dimensions, Color color) {
+ 			spriteBatch.Draw(texture, new Rectangle(dimensions.X, dimensions.Y - 6, dimensions.Width, 6), new Rectangle(0, 0, texture.Width, 6), color);
+ 			spriteBatch.Draw(texture, new Rectangle(dimensions.X, dimensions.Y, dimensions.Width, dimensions.Height), new Rectangle(0, 6, texture.Width, 4), color);
+ 			spriteBatch.Draw(texture, new Rectangle(dimensions.X, dimensions.Y + dimensions.Height, dimensions.Width, 6), new Rectangle(0, texture.Height - 6, texture.Width, 6), color);

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -370,6 +370,10 @@
 		"MouseXButton1": "Mouse 4",
 		"MouseXButton2": "Mouse 5",
 
+		// In Game UI additions
+		"slotStack": "Stack",
+		"slotScroll": "Scroll",
+
 		// Misc
 		"OK": "OK",
 		"Continue": "Continue",

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.GameContent;
@@ -37,6 +32,15 @@ namespace Terraria
 		public static Color DiscoColor => new Color(DiscoR, DiscoG, DiscoB);
 		public static Color MouseTextColorReal => new Color(mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f);
 		public static bool PlayerLoaded => CurrentFrameFlags.ActivePlayersCount > 0;
+
+
+		private static Player _currentPlayerOverride;
+
+		/// <summary>
+		/// A replacement for `Main.LocalPlayer` which respects whichever player is currently running hooks on the main thread.
+		/// This works in the player select screen, and in multiplayer (when other players are updating)
+		/// </summary>
+		public static Player CurrentPlayer => _currentPlayerOverride ?? LocalPlayer;
 
 		public static void InfoDisplayPageHandler(int startX, ref string mouseText, out int startingDisplay, out int endingDisplay) {
 			startingDisplay = 0;
@@ -116,6 +120,20 @@ namespace Terraria
 					NetMessage.SendData(7);
 
 				oldMaxRaining = maxRaining;
+			}
+		}
+
+		public ref struct CurrentPlayerOverride
+		{
+			private Player _prevPlayer;
+
+			public CurrentPlayerOverride(Player player) {
+				_prevPlayer = _currentPlayerOverride;
+				_currentPlayerOverride = player;
+			}
+
+			public void Dispose() {
+				_currentPlayerOverride = _prevPlayer;
 			}
 		}
 	}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1313,6 +1313,27 @@
  			if (!dedServ && (double)screenPosition.Y < worldSurface * 16.0 + 16.0 && netMode != 2) {
  				Star.UpdateStars();
  				Cloud.UpdateClouds();
+@@ -12753,6 +_,10 @@
+ 
+ 			if (playerInventory) {
+ 				Recipe.GetThroughDelayedFindRecipes();
++
++				if (PlayerInput.MouseInModdedUI.Count != 0)
++					goto noScrollOnLocked;
++
+ 				int num = PlayerInput.ScrollWheelDelta / 120;
+ 				bool flag = true;
+ 				if (recBigList) {
+@@ -12793,6 +_,9 @@
+ 						focusRecipe = 0;
+ 				}
+ 
++			noScrollOnLocked:
++				PlayerInput.MouseInModdedUI.Clear();
++
+ 				Main.player[myPlayer].dropItemCheck();
+ 			}
+ 
 @@ -12836,7 +_,13 @@
  				InGameUI.Update(gameTime);
  
@@ -2726,7 +2747,7 @@
  					if (player[myPlayer].buffType[n] != 0) {
  						int num32 = num28 / num29;
  						int num33 = num28 % num29;
-@@ -30086,10 +_,12 @@
+@@ -30086,17 +_,19 @@
  						if (num34 == 147)
  							bannerMouseOver = true;
  
@@ -2742,6 +2763,84 @@
  					}
  				}
  			}
+ 			else if (EquipPage == 1) {
+ 				DrawNPCHousesInUI();
+ 			}
+-			else {
++			else if (EquipPage == 0) {// allow mods to add custom equip pages
+ 				int num35 = 4;
+ 				if (mouseX > screenWidth - 64 - 28 && mouseX < (int)((float)(screenWidth - 64 - 28) + 56f * inventoryScale) && mouseY > num20 && mouseY < (int)((float)num20 + 448f * inventoryScale) && !PlayerInput.IgnoreMouseInterface)
+ 					player[myPlayer].mouseInterface = true;
+@@ -30113,7 +_,7 @@
+ 				Microsoft.Xna.Framework.Color color = inventoryBack;
+ 				Microsoft.Xna.Framework.Color color2 = new Microsoft.Xna.Framework.Color(80, 80, 80, 80);
+ 				int num39 = -1;
+-				for (int num40 = 0; num40 < 10; num40++) {
++				for (int num40 = 0; num40 < 3; num40++) {
+ 					if ((num40 == 8 && !flag4) || (num40 == 9 && !flag5))
+ 						continue;
+ 
+@@ -30134,6 +_,7 @@
+ 						context2 = 10;
+ 					}
+ 
++					/*
+ 					if (num39 == num38 && !_achievementAdvisor.CanDrawAboveCoins) {
+ 						_achievementAdvisor.DrawOneAchievement(spriteBatch, new Vector2(num41 - 10 - 47 - 47 - 14 - 14, num42 + 8), large: false);
+ 						UILinkPointNavigator.SetPosition(1570, new Vector2(num41 - 10 - 47 - 47 - 14 - 14, num42 + 8) + new Vector2(20f) * inventoryScale);
+@@ -30141,6 +_,7 @@
+ 
+ 					if (num39 == num37)
+ 						DrawDefenseCounter(num41, num42);
++					*/ 
+ 
+ 					Texture2D value4 = TextureAssets.InventoryTickOn.Value;
+ 					if (player[myPlayer].hideVisibleAccessory[num40])
+@@ -30187,10 +_,10 @@
+ 					player[myPlayer].mouseInterface = true;
+ 
+ 				num39 = -1;
+-				for (int num46 = 10; num46 < 20; num46++) {
++				for (int num46 = 10; num46 < 13; num46++) {
+ 					if ((num46 == 18 && !flag4) || (num46 == 19 && !flag5))
+ 						continue;
+-
++					
+ 					num39++;
+ 					bool num47 = LocalPlayer.IsAValidEquipmentSlotForIteration(num46);
+ 					flag3 = !num47;
+@@ -30228,7 +_,7 @@
+ 					player[myPlayer].mouseInterface = true;
+ 
+ 				num39 = -1;
+-				for (int num50 = 0; num50 < 10; num50++) {
++				for (int num50 = 0; num50 < 3; num50++) {
+ 					if ((num50 == 8 && !flag4) || (num50 == 9 && !flag5))
+ 						continue;
+ 
+@@ -30263,9 +_,22 @@
+ 				}
+ 
+ 				inventoryBack = color;
++				int chkMax = (int)((float)(num20) + (float)((7 + LocalPlayer.GetAmountOfExtraAccessorySlotsToShow()) * 56) * Main.inventoryScale) + 4;
++				int randomLocationX = screenWidth - 64 - 28;
++
++				if (num39 == num38 && !_achievementAdvisor.CanDrawAboveCoins) {
++					_achievementAdvisor.DrawOneAchievement(spriteBatch, new Vector2(randomLocationX - 10 - 47 - 47 - 14 - 14, chkMax + 8), large: false);
++					UILinkPointNavigator.SetPosition(1570, new Vector2(randomLocationX - 10 - 47 - 47 - 14 - 14, chkMax + 8) + new Vector2(20f) * inventoryScale);
++				}
++
++				DrawDefenseCounter(randomLocationX, chkMax);
++
++				inventoryBack = color;
+ 				inventoryScale = num36;
+ 			}
+ 
++			LoaderManager.Get<AccessorySlotLoader>().DrawAccSlots(num20);
++
+ 			int num54 = (screenHeight - 600) / 2;
+ 			int num55 = (int)((float)screenHeight / 600f * 250f);
+ 			if (screenHeight < 700) {
 @@ -30309,11 +_,17 @@
  					string text = Lang.inter[46].Value + ": ";
  					if (reforgeItem.type > 0) {

--- a/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
@@ -1,0 +1,466 @@
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Linq;
+using Terraria.GameContent;
+using Terraria.ID;
+using Terraria.UI;
+using Terraria.Audio;
+using Microsoft.Xna.Framework;
+using Terraria.GameInput;
+using Terraria.Localization;
+using Terraria.ModLoader.Default;
+using Terraria.GameContent.UI.Elements;
+
+namespace Terraria.ModLoader
+{
+	//TODO: further documentation
+	/// <summary>
+	/// This serves as a central place to store equipment slots and their corresponding textures. You will use this to obtain the IDs for your equipment textures.
+	/// </summary>
+	public class AccessorySlotLoader : Loader<ModAccessorySlot> {
+		static Player Player => Main.LocalPlayer;
+		static internal ModAccessorySlotPlayer ModSlotPlayer(Player player) => player.GetModPlayer<ModAccessorySlotPlayer>();
+
+		public AccessorySlotLoader() => Initialize(0);
+
+		public ModAccessorySlot Get(int id, Player player) => list[id % ModSlotPlayer(player).SlotCount()];
+		public ModAccessorySlot Get(int id) => Get(id, Player);
+
+		public const int MaxVanillaSlotCount = 2 + 5;
+
+		// DRAWING CODE ///////////////////////////////////////////////////////////////////
+		internal int GetAccessorySlotPerColumn() {
+			float minimumClearance = DrawVerticalAlignment + 2 * 56 * Main.inventoryScale + 4;
+			return (int)((Main.screenHeight - minimumClearance) / (56 * Main.inventoryScale) - 1.8f);
+		}
+
+		/// <summary>
+		/// The variable known as num20 used to align all equipment slot drawing in Main.
+		/// Represents the y position where equipment slots start to be drawn from.
+		/// </summary>
+		static public int DrawVerticalAlignment { get; private set; }
+
+		public void DrawAccSlots(int num20) {
+			int skip = 0;
+			DrawVerticalAlignment = num20;
+			Color color = Main.inventoryBack;
+
+			for (int vanillaSlot = 3; vanillaSlot < Player.dye.Length; vanillaSlot++) {
+				if (!Draw(skip, false, vanillaSlot, color)) {
+					skip++;
+				}
+			}
+
+			for (int modSlot = 0; modSlot < list.Count; modSlot++) {
+				if (!Draw(skip, true, modSlot, color))
+					skip++;
+			}
+
+			// there are no slots to be drawn by us.
+			if (skip == MaxVanillaSlotCount + list.Count) {
+				ModSlotPlayer(Player).scrollbarSlotPosition = 0;
+				return;
+			}
+
+			int accessoryPerColumn = GetAccessorySlotPerColumn();
+			int slotsToRender = list.Count + MaxVanillaSlotCount - skip;
+			int scrollIncrement = slotsToRender - accessoryPerColumn;
+
+			if (scrollIncrement > 0) {
+				DrawScrollSwitch();
+
+				if (ModSlotPlayer(Player).scrollSlots) {
+					DrawScrollbar(accessoryPerColumn, slotsToRender, scrollIncrement);
+				}
+			}
+			else
+				ModSlotPlayer(Player).scrollbarSlotPosition = 0;
+		}
+
+		public static string[] scrollStackLang = { Language.GetTextValue("tModLoader.slotStack"), Language.GetTextValue("tModLoader.slotScroll") }; 
+
+		internal void DrawScrollSwitch() {
+			Texture2D value4 = TextureAssets.InventoryTickOn.Value;
+			if (ModSlotPlayer(Player).scrollSlots)
+				value4 = TextureAssets.InventoryTickOff.Value;
+
+			int xLoc2 = Main.screenWidth - 64 - 28 + 47 + 9;
+			int yLoc2 = (int)((float)(DrawVerticalAlignment) + (float)((0 + 3) * 56) * Main.inventoryScale) - 10;
+
+			Main.spriteBatch.Draw(value4, new Vector2(xLoc2, yLoc2), Color.White * 0.7f);
+
+			Rectangle rectangle = new Rectangle(xLoc2, yLoc2, value4.Width, value4.Height);
+			if (!(rectangle.Contains(new Point(Main.mouseX, Main.mouseY)) && !PlayerInput.IgnoreMouseInterface)) {
+				return;
+			}
+
+			Player player = Main.LocalPlayer;
+			player.mouseInterface = true;
+			if (Main.mouseLeft && Main.mouseLeftRelease) {
+				ModSlotPlayer(Player).scrollSlots = !ModSlotPlayer(Player).scrollSlots;
+				SoundEngine.PlaySound(12);
+			}
+
+			int num45 = ((!ModSlotPlayer(Player).scrollSlots) ? 0 : 1);
+			Main.HoverItem = new Item();
+			Main.hoverItemName = scrollStackLang[num45];
+		}
+
+		// This is a hacky solution to make it very vanilla-esque, at the cost of not actually using a UI proper. 
+		internal void DrawScrollbar(int accessoryPerColumn, int slotsToRender, int scrollIncrement) {
+			int xLoc = Main.screenWidth - 64 - 28;
+
+			if (scrollIncrement < 0) {
+				accessoryPerColumn = slotsToRender;
+				scrollIncrement = 0;
+			}
+
+			int chkMax = (int)((float)(DrawVerticalAlignment) + (float)(((accessoryPerColumn) + 3) * 56) * Main.inventoryScale) + 4;
+			int chkMin = (int)((float)(DrawVerticalAlignment) + (float)((0 + 3) * 56) * Main.inventoryScale) + 4;
+
+			UIScrollbar scrollbar = new UIScrollbar();
+
+			Rectangle rectangle = new Rectangle(xLoc + 47 + 6, chkMin, 5, chkMax - chkMin);
+			scrollbar.DrawBar(Main.spriteBatch, Main.Assets.Request<Texture2D>("Images/UI/Scrollbar").Value, rectangle, Color.White);
+			
+			int barSize = (chkMax - chkMin) / (scrollIncrement + 1);
+			rectangle = new Rectangle(xLoc + 47 + 5, chkMin + ModSlotPlayer(Player).scrollbarSlotPosition * barSize, 3, barSize);
+			scrollbar.DrawBar(Main.spriteBatch, Main.Assets.Request<Texture2D>("Images/UI/ScrollbarInner").Value, rectangle, Color.White);
+
+			rectangle = new Rectangle(xLoc - 47 * 2, chkMin, 47 * 3, chkMax - chkMin);
+			if (!(rectangle.Contains(new Point(Main.mouseX, Main.mouseY)) && !PlayerInput.IgnoreMouseInterface)) {
+				return;
+			}
+
+			PlayerInput.LockVanillaMouseScroll("ModLoader/Acc");
+
+			int scrollDelta = ModSlotPlayer(Player).scrollbarSlotPosition + (int)PlayerInput.ScrollWheelDelta / 120;
+			scrollDelta = Math.Min(scrollDelta, scrollIncrement);
+			scrollDelta = Math.Max(scrollDelta, 0);
+
+			ModSlotPlayer(Player).scrollbarSlotPosition = scrollDelta;
+			PlayerInput.ScrollWheelDelta = 0;
+		}
+
+		int slotDrawLoopCounter = 0;
+
+		/// <summary>
+		/// Draws Vanilla and Modded Accessory Slots
+		/// </summary>
+		public bool Draw(int skip, bool modded, int slot, Color color) {
+			bool flag3;
+			bool flag4 = false;
+
+			if (modded) {
+				flag3 = !ModdedIsAValidEquipmentSlotForIteration(slot, Player);
+				flag4 = !ModdedCanSlotBeShown(slot);
+			}
+			else {
+				flag3 = !Player.IsAValidEquipmentSlotForIteration(slot);
+				if (slot == 8) {
+					flag4 = (slot == 8) && !Player.CanDemonHeartAccessoryBeShown();
+				}
+				else if (slot == 9) {
+					flag4 = !Player.CanMasterModeAccessoryBeShown();
+				}
+			}
+
+			if (flag4 && flag3 || modded && IsHidden(slot)) {
+				return false;
+			}
+
+			Main.inventoryBack = flag3 ? new Color(80, 80, 80, 80) : color;
+			slotDrawLoopCounter = 0;
+			int yLoc = 0, xLoc = 0;
+			bool customLoc = false;
+
+			if (modded) {
+				ModAccessorySlot mAccSlot = list[slot];
+				customLoc = mAccSlot.CustomLocation.HasValue;
+				if (!customLoc && Main.EquipPage != 0)
+					return false;
+
+				if (customLoc) {
+					xLoc = (int)mAccSlot.CustomLocation?.X;
+					yLoc = (int)mAccSlot.CustomLocation?.Y;
+				}
+				else if (!SetDrawLocation(slot + Player.dye.Length - 3, skip, ref xLoc, ref yLoc))
+					return true;
+
+				var thisSlot = Get(slot);
+
+				if (thisSlot.DrawFunctionalSlot) {
+					bool skipMouse = DrawVisibility(ref ModSlotPlayer(Player).exHideAccessory[slot], -10, xLoc, yLoc, out var xLoc2, out var yLoc2, out var value4);
+					DrawSlot(ModSlotPlayer(Player).exAccessorySlot, -10, slot, flag3, xLoc, yLoc, skipMouse);
+					Main.spriteBatch.Draw(value4, new Vector2(xLoc2, yLoc2), Color.White * 0.7f);
+				}
+				if (thisSlot.DrawVanitySlot)
+					DrawSlot(ModSlotPlayer(Player).exAccessorySlot, -11, slot + list.Count, flag3, xLoc, yLoc);
+				if (thisSlot.DrawDyeSlot)
+					DrawSlot(ModSlotPlayer(Player).exDyesAccessory, -12, slot, flag3, xLoc, yLoc);
+			}
+			else {
+				if (!customLoc && Main.EquipPage != 0)
+					return false;
+				if (!SetDrawLocation(slot - 3, skip, ref xLoc, ref yLoc))
+					return true;
+
+				bool skipMouse = DrawVisibility(ref Player.hideVisibleAccessory[slot], 10, xLoc, yLoc, out var xLoc2, out var yLoc2, out var value4);
+				DrawSlot(Player.armor, 10, slot, flag3, xLoc, yLoc, skipMouse);
+				Main.spriteBatch.Draw(value4, new Vector2(xLoc2, yLoc2), Color.White * 0.7f);
+				DrawSlot(Player.armor, 11, slot + Player.dye.Length, flag3, xLoc, yLoc);
+				DrawSlot(Player.dye, 12, slot, flag3, xLoc, yLoc);
+			}
+
+			return !customLoc;
+		}
+
+		/// <summary>
+		/// Applies Xloc and Yloc data for the slot, based on ModAccessorySlotPlayer.scrollSlots
+		/// </summary>
+		internal bool SetDrawLocation(int trueSlot, int skip, ref int xLoc, ref int yLoc) {
+			int accessoryPerColumn = GetAccessorySlotPerColumn();
+			int xColumn = (int)(trueSlot / accessoryPerColumn);
+			int yRow = trueSlot % accessoryPerColumn;
+						
+			if (ModSlotPlayer(Player).scrollSlots) {
+				int row = yRow + (xColumn) * accessoryPerColumn - ModSlotPlayer(Player).scrollbarSlotPosition - skip;
+
+				yLoc = (int)((float)(DrawVerticalAlignment) + (float)((row + 3) * 56) * Main.inventoryScale) + 4;
+				int chkMin = (int)((float)(DrawVerticalAlignment) + (float)((0 + 3) * 56) * Main.inventoryScale) + 4;
+				int chkMax = (int)((float)(DrawVerticalAlignment) + (float)(((accessoryPerColumn - 1) + 3) * 56) * Main.inventoryScale) + 4;
+
+				if (yLoc > chkMax || yLoc < chkMin) {
+					return false;
+				}
+
+				xLoc = Main.screenWidth - 64 - 28;
+			}
+
+			else {
+				int row = yRow, tempSlot = trueSlot, col = xColumn;
+				if (skip > 0) {
+					tempSlot -= skip;
+					row = tempSlot % accessoryPerColumn;
+					col = tempSlot / accessoryPerColumn;
+				}
+
+				yLoc = (int)((float)(DrawVerticalAlignment) + (float)((row + 3) * 56) * Main.inventoryScale) + 4;
+				if (col > 0) {
+					xLoc = Main.screenWidth - 64 - 28 - 47 * 3 * col - 50;
+				}
+				else {
+					xLoc = Main.screenWidth - 64 - 28 - 47 * 3 * col;
+				}
+			}
+			
+			return true;
+		}
+
+		/// <summary>
+		/// Is run in AccessorySlotLoader.Draw. 
+		/// Creates & sets up Hide Visibility Button.
+		/// </summary>
+		internal bool DrawVisibility(ref bool visbility, int context, int xLoc, int yLoc, out int xLoc2, out int yLoc2, out Texture2D value4) {
+			yLoc2 = yLoc - 2;
+			xLoc2 = xLoc - 58 + 64 + 28;
+
+			value4 = TextureAssets.InventoryTickOn.Value;
+			if (visbility)
+				value4 = TextureAssets.InventoryTickOff.Value;
+
+			Rectangle rectangle = new Rectangle(xLoc2, yLoc2, value4.Width, value4.Height);
+			int num45 = 0;
+			bool skipCheck = false;
+			if (rectangle.Contains(new Point(Main.mouseX, Main.mouseY)) && !PlayerInput.IgnoreMouseInterface) {
+				skipCheck = true;
+				Player.mouseInterface = true;
+				
+				if (Main.mouseLeft && Main.mouseLeftRelease) {
+					visbility = !visbility;
+					SoundEngine.PlaySound(12);
+					
+					if (Main.netMode == 1 && context > 0)
+						NetMessage.SendData(4, -1, -1, null, Player.whoAmI);
+				}
+
+				num45 = ((!visbility) ? 1 : 2);
+			}
+
+			if (num45 > 0) {
+				Main.HoverItem = new Item();
+				Main.hoverItemName = Lang.inter[58 + num45].Value;
+			}
+
+			return skipCheck;
+		}
+
+		/// <summary>
+		/// Is run in AccessorySlotLoader.Draw. 
+		/// Generates a significant amount of functionality for the slot, despite being named drawing because vanilla.
+		/// At the end, calls this.DrawRedirect to enable custom drawing
+		/// </summary>
+		internal void DrawSlot(Item[] items, int context, int slot, bool flag3, int xLoc, int yLoc, bool skipCheck = false) {
+			bool flag = flag3 && !Main.mouseItem.IsAir;
+			int xLoc1 = xLoc - 47 * (slotDrawLoopCounter++);
+			bool isHovered = false;
+
+			if (!skipCheck && Main.mouseX >= xLoc1 && (float)Main.mouseX <= (float)xLoc1 + (float)TextureAssets.InventoryBack.Width() * Main.inventoryScale && Main.mouseY >= yLoc
+				&& (float)Main.mouseY <= (float)yLoc + (float)TextureAssets.InventoryBack.Height() * Main.inventoryScale && !PlayerInput.IgnoreMouseInterface) {
+				isHovered = true;
+
+				Player.mouseInterface = true;
+				Main.armorHide = true;
+				ItemSlot.OverrideHover(items, Math.Abs(context), slot);
+
+				if (!flag) {
+					if (Math.Abs(context) == 12) {
+						if (Main.mouseRightRelease && Main.mouseRight)
+							ItemSlot.RightClick(items, context, slot);
+
+						ItemSlot.LeftClick(items, context, slot);
+					}
+					else if (Math.Abs(context) == 11) {
+						ItemSlot.LeftClick(items, context, slot);
+						ItemSlot.RightClick(items, context, slot);
+					}
+					else if (Math.Abs(context) == 10) {
+						ItemSlot.LeftClick(items, context, slot);
+					}
+				}
+
+				ItemSlot.MouseHover(items, Math.Abs(context), slot);
+				
+				if (context < 0)
+					OnHover(slot, context);
+			}
+			DrawRedirect(items, context, slot, new Vector2(xLoc1, yLoc), isHovered);
+		}
+
+		internal void DrawRedirect(Item[] inv, int context, int slot, Vector2 location, bool isHovered) {
+			if (context < 0) {
+				if (Get(slot).PreDraw(ContextToEnum(context), inv[slot], location, isHovered))
+					ItemSlot.Draw(Main.spriteBatch, inv, context, slot, location);
+
+				Get(slot).PostDraw(ContextToEnum(context), inv[slot], location, isHovered);
+			}
+			else {
+				ItemSlot.Draw(Main.spriteBatch, inv, context, slot, location);
+			}
+		}
+
+		/// <summary>
+		/// Provides the Texture for a Modded Accessory Slot
+		/// This probably will need optimization down the road.
+		/// </summary>
+		internal Texture2D GetBackgroundTexture(int slot, int context) {
+			var thisSlot = Get(slot);
+			switch (context) {
+				case -10:
+					if (ModContent.RequestIfExists<Texture2D>(thisSlot.FunctionalBackgroundTexture, out var funcTexture))
+						return funcTexture.Value;
+					return TextureAssets.InventoryBack3.Value;
+				case -11:
+					if (ModContent.RequestIfExists<Texture2D>(thisSlot.VanityBackgroundTexture, out var vanityTexture))
+						return vanityTexture.Value;
+					return TextureAssets.InventoryBack8.Value;
+				case -12:
+					if (ModContent.RequestIfExists<Texture2D>(thisSlot.DyeBackgroundTexture, out var dyeTexture))
+						return dyeTexture.Value;
+					return TextureAssets.InventoryBack12.Value;
+			}
+			
+			// Default to a functional slot
+			return TextureAssets.InventoryBack3.Value;
+		}
+
+		internal void DrawSlotTexture(Texture2D value6, Vector2 position, Rectangle rectangle, Color color, float rotation, Vector2 origin, float scale, SpriteEffects effects, float layerDepth, int slot, int context) {
+			var thisSlot = Get(slot);
+			Texture2D texture = null;
+			switch (context) {
+				case -10:
+					if (ModContent.RequestIfExists<Texture2D>(thisSlot.FunctionalTexture, out var funcTexture))
+						texture = funcTexture.Value;
+					break;
+				case -11:
+					if (ModContent.RequestIfExists<Texture2D>(thisSlot.VanityTexture, out var vanityTexture))
+						texture = vanityTexture.Value;
+					break;
+				case -12:
+					if (ModContent.RequestIfExists<Texture2D>(thisSlot.DyeTexture, out var dyeTexture))
+						texture = dyeTexture.Value;
+					break;
+			}
+
+			if (texture == null)
+				texture = value6;
+			else
+				rectangle = new Rectangle(0, 0, 32, 32);
+
+			Main.spriteBatch.Draw(texture, position, rectangle, color, rotation, origin, scale, effects, layerDepth);
+		}
+
+		// Functionality Related Code /////////////////////////////////////////////////////////////////////
+
+		public AccessorySlotType ContextToEnum(int context) => (AccessorySlotType)Math.Abs(context);
+
+		public bool ModdedIsAValidEquipmentSlotForIteration(int index, Player player) => Get(index, player).IsEnabled();
+
+		public void CustomUpdateEquips(int index, Player player) => Get(index, player).ApplyEquipEffects();
+
+		public bool ModdedCanSlotBeShown(int index) => Get(index).IsVisibleWhenNotEnabled();
+
+		public bool IsHidden(int index) => Get(index).IsHidden();
+
+		public bool CanAcceptItem(int index, Item checkItem, int context) => Get(index).CanAcceptItem(checkItem, ContextToEnum(context));
+
+		public void OnHover(int index, int context) => Get(index).OnMouseHover(ContextToEnum(context));
+
+		/// <summary>
+		/// Checks if the provided item can go in to the provided slot. 
+		/// Includes checking if the item already exists in either of Player.Armor or ModSlotPlayer.exAccessorySlot
+		/// Invokes directly ItemSlot.AccCheck & ModSlot.CanAcceptItem
+		/// </summary>
+		public bool ModSlotCheck(Item checkItem, int slot, int context) => CanAcceptItem(slot, checkItem, context) &&
+			!ItemSlot.AccCheck(Player.armor.Concat(ModSlotPlayer(Player).exAccessorySlot).ToArray(), checkItem, slot + Player.armor.Length);
+
+		/// <summary>
+		/// After checking for empty slots in ItemSlot.AccessorySwap, this allows for changing what the target slot will be if the accessory isn't already equipped.
+		/// DOES NOT affect vanilla behaviour of swapping items like for like where existing in a slot
+		/// </summary>
+		public void ModifyDefaultSwapSlot(Item item, ref int accSlotToSwapTo) {
+			for (int num = ModSlotPlayer(Player).SlotCount() - 1; num >= 0; num--) {
+				if (ModdedIsAValidEquipmentSlotForIteration(num, Player)) {
+					if (Get(num).ModifyDefaultSwapSlot(item, accSlotToSwapTo)) {
+						accSlotToSwapTo = num + 20;
+					}
+				}
+			}
+		}
+
+		//TODO: Look into if this should have an actual hook later, and which class to associate to (item or player). Not a priority to the Accessory Slot ModType PR
+		/// <summary>
+		/// Mirrors Player.GetPreferredGolfBallToUse.
+		/// Provides the golf ball projectile from an accessory slot. 
+		/// </summary>
+		public bool PreferredGolfBall(ref int projType) {
+			for (int num = ModSlotPlayer(Player).SlotCount() * 2 - 1; num >= 0; num--) {
+				if (ModdedIsAValidEquipmentSlotForIteration(num, Player)) {
+					Item item2 = ModSlotPlayer(Player).exAccessorySlot[num];
+					if (!item2.IsAir && item2.shoot > 0 && ProjectileID.Sets.IsAGolfBall[item2.shoot]) {
+						projType = item2.shoot;
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+	}
+
+	public enum AccessorySlotType
+	{
+		FunctionalSlot = 10,
+		VanitySlot = 11,
+		DyeSlot = 12
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Terraria.ModLoader.IO;
+
+namespace Terraria.ModLoader.Default
+{
+	// Test in Multiplayer, suspect there is some issue with synchronization of unloaded slots
+	public class ModAccessorySlotPlayer : ModPlayer
+	{
+		public override bool CloneNewInstances => false;
+		internal static AccessorySlotLoader Loader => LoaderManager.Get<AccessorySlotLoader>();
+
+		internal int SlotCount() => slots.Count;
+
+		// Arrays for modded accessory slot save/load/usage. Used in DefaultPlayer.
+		internal Item[] exAccessorySlot = new Item[2];
+		internal Item[] exDyesAccessory = new Item[1];
+		internal bool[] exHideAccessory = new bool[1];
+		internal Dictionary<string, int> slots = new Dictionary<string, int>();
+
+		// Setting toggle for stack or scroll accessories/npcHousing
+		internal bool scrollSlots = true;
+		internal int scrollbarSlotPosition = 0;
+
+		public ModAccessorySlotPlayer() {
+			foreach (var slot in Loader.list) {
+				if (!slot.FullName.StartsWith("Terraria", StringComparison.OrdinalIgnoreCase))
+					slots.Add(slot.FullName, slot.Type);
+				else
+					slots.Add(slot.Name, slot.Type);
+			}
+
+			ResizeAccesoryArrays(slots.Count);
+		}
+
+		internal void ResizeAccesoryArrays(int newSize) {
+			if (newSize < slots.Count) {
+				return;
+			}
+
+			Array.Resize<Item>(ref exAccessorySlot, 2 * newSize);
+			Array.Resize<Item>(ref exDyesAccessory, newSize);
+			Array.Resize<bool>(ref exHideAccessory, newSize);
+
+			for (int i = 0; i < newSize; i++) {
+				exDyesAccessory[i] = new Item();
+				exHideAccessory[i] = false;
+
+				exAccessorySlot[i * 2] = new Item();
+				exAccessorySlot[i * 2 + 1] = new Item();
+			}
+		}
+
+		public override void SaveData(TagCompound tag) {
+			tag["order"] = slots.Keys.ToList();
+			tag["items"] = exAccessorySlot.Select(ItemIO.Save).ToList();
+			tag["dyes"] = exDyesAccessory.Select(ItemIO.Save).ToList();
+			tag["visible"] = exHideAccessory.ToList();
+		}
+
+		public override void LoadData(TagCompound tag) {
+			var order = tag.GetList<string>("order").ToList();
+			var items = tag.GetList<TagCompound>("items").Select(ItemIO.Load).ToList();
+			var dyes = tag.GetList<TagCompound>("dyes").Select(ItemIO.Load).ToList();
+			var visible = tag.GetList<bool>("visible").ToList();
+
+			ResizeAccesoryArrays(order.Count);
+
+			for (int i = 0; i < order.Count; i++) {
+				// Try finding the slot item goes in to
+				if (!slots.TryGetValue(order[i], out int type)) {
+					var unloaded = new UnloadedAccessorySlot(Loader.list.Count, order[i]);
+
+					slots.Add(unloaded.Name, unloaded.Type);
+					Loader.list.Add(unloaded);
+					type = unloaded.Type;
+				}
+
+				// Place loaded items in to the correct slot
+				exDyesAccessory[type] = dyes[i];
+				exHideAccessory[type] = visible[i];
+				exAccessorySlot[type] = items[i];
+				exAccessorySlot[type + order.Count] = items[i + order.Count];
+			}
+		}
+
+		// Updates Code:
+		/// <summary>
+		/// Updates functional slot visibility information on the player for Mod Slots, in a similar fashion to Player.UpdateVisibleAccessories()
+		/// </summary>
+		public override void UpdateVisibleAccessories() {
+			var loader = LoaderManager.Get<AccessorySlotLoader>();
+
+			for (int k = 0; k < SlotCount(); k++) {
+				if (loader.ModdedIsAValidEquipmentSlotForIteration(k, Player)) {
+					Player.UpdateVisibleAccessories(exAccessorySlot[k], exHideAccessory[k], k, true);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Updates vanity slot information on the player for Mod Slots, in a similar fashion to Player.UpdateVisibleAccessories()
+		/// </summary>
+		public override void UpdateVisibleVanityAccessories() {
+			var loader = LoaderManager.Get<AccessorySlotLoader>();
+
+			for (int k = 0; k < SlotCount(); k++) {
+				if (loader.ModdedIsAValidEquipmentSlotForIteration(k, Player)) {
+					var vanitySlot = k + SlotCount();
+					if (!Player.ItemIsVisuallyIncompatible(exAccessorySlot[vanitySlot]))
+						Player.UpdateVisibleAccessory(vanitySlot, exAccessorySlot[vanitySlot], true);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Mirrors Player.UpdateDyes() for modded slots
+		/// Runs On Player Select, so is Player instance sensitive!!!
+		/// </summary>
+		public override void UpdateDyes() {
+			var loader = LoaderManager.Get<AccessorySlotLoader>();
+
+			for (int i = 0; i < SlotCount() * 2; i++) {
+				if (loader.ModdedIsAValidEquipmentSlotForIteration(i, Player)) {
+					int num = i % exDyesAccessory.Length;
+					Player.UpdateItemDye(i < exDyesAccessory.Length, exHideAccessory[num], exAccessorySlot[i], exDyesAccessory[num]);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Runs a simplified version of Player.UpdateEquips for the Modded Accessory Slots
+		/// </summary>
+		public override void UpdateEquips() {
+			var loader = LoaderManager.Get<AccessorySlotLoader>();
+
+			for (int k = 0; k < SlotCount(); k++) {
+				if (loader.ModdedIsAValidEquipmentSlotForIteration(k, Player)) {
+					loader.CustomUpdateEquips(k, Player);
+				}
+			}
+		}
+
+		// Death drops code, should run prior to dropping other items in case conditions are used based on player's current equips
+		public void DropItems() {
+			var loader = LoaderManager.Get<AccessorySlotLoader>();
+			var pos = Player.position + Player.Size / 2;
+			for (int i = 0; i < SlotCount(); i++) {
+				if (loader.ModdedIsAValidEquipmentSlotForIteration(i, Player)) {
+					Player.DropItem(pos, ref exAccessorySlot[i]);
+					Player.DropItem(pos, ref exAccessorySlot[i + SlotCount()]);
+					Player.DropItem(pos, ref exDyesAccessory[i]);
+				}
+			}
+		}
+
+		// The following netcode is adapted from ChickenBone's UtilitySlots:
+		public override void clientClone(ModPlayer clientClone) {
+			var defaultInv = (ModAccessorySlotPlayer)clientClone;
+			for (int i = 0; i < exAccessorySlot.Length; i++)
+				defaultInv.exAccessorySlot[i] = exAccessorySlot[i].Clone();
+			for (int i = 0; i < exDyesAccessory.Length; i++) {
+				defaultInv.exDyesAccessory[i] = exDyesAccessory[i].Clone();
+				defaultInv.exHideAccessory[i] = exHideAccessory[i];
+			}
+		}
+
+		public override void SyncPlayer(int toWho, int fromWho, bool newPlayer) {
+			for (int i = 0; i < exAccessorySlot.Length; i++)
+				NetHandler.SendSlot(toWho, Player.whoAmI, i, exAccessorySlot[i]);
+
+			for (int i = 0; i < exDyesAccessory.Length; i++) {
+				NetHandler.SendSlot(toWho, Player.whoAmI, -i - 1, exDyesAccessory[i]);
+				NetHandler.SendVisualState(toWho, Player.whoAmI, i, exHideAccessory[i]);
+			}
+		}
+
+		public override void SendClientChanges(ModPlayer clientPlayer) {
+			var clientInv = (ModAccessorySlotPlayer)clientPlayer;
+			for (int i = 0; i < exAccessorySlot.Length; i++)
+				if (exAccessorySlot[i].IsNotTheSameAs(clientInv.exAccessorySlot[i]))
+					NetHandler.SendSlot(-1, Player.whoAmI, i, exAccessorySlot[i]);
+
+			for (int i = 0; i < exDyesAccessory.Length; i++) {
+				if (exDyesAccessory[i].IsNotTheSameAs(clientInv.exDyesAccessory[i]))
+					NetHandler.SendSlot(-1, Player.whoAmI, -i - 1, exDyesAccessory[i]);
+
+				if (exHideAccessory[i] != clientInv.exHideAccessory[i])
+					NetHandler.SendVisualState(-1, Player.whoAmI, i, exHideAccessory[i]);
+			}
+		}
+
+		internal class NetHandler
+		{
+			public const byte InventorySlot = 1;
+			public const byte VisualState = 2;
+
+			public const byte Server = 2;
+			public const byte Client = 1;
+			public const byte SP = 0;
+
+			public static void SendSlot(int toWho, int plr, int slot, Item item) {
+				var p = ModContent.GetInstance<ModLoaderMod>().GetPacket();
+
+				p.Write(InventorySlot);
+
+				if (Main.netMode == Server)
+					p.Write((sbyte)plr);
+
+				p.Write((sbyte)slot);
+
+				ItemIO.Send(item, p, true);
+				p.Send(toWho, plr);
+			}
+
+			private static void HandleSlot(BinaryReader r, int fromWho) {
+				if (Main.netMode == Client)
+					fromWho = r.ReadByte();
+
+				var dPlayer = Main.player[fromWho].GetModPlayer<ModAccessorySlotPlayer>();
+
+				sbyte slot = r.ReadSByte();
+				var item = ItemIO.Receive(r, true);
+
+				SetSlot(slot, item, dPlayer);
+
+				if (Main.netMode == 2)
+					SendSlot(-1, fromWho, slot, item);
+			}
+
+			public static void SendVisualState(int toWho, int plr, int slot, bool hideVisual) {
+				var p = ModContent.GetInstance<ModLoaderMod>().GetPacket();
+
+				p.Write(VisualState);
+
+				if (Main.netMode == Server)
+					p.Write((byte)plr);
+
+				p.Write((sbyte)slot);
+
+				p.Write(hideVisual);
+				p.Send(toWho, plr);
+			}
+
+			private static void HandleVisualState(BinaryReader r, int fromWho) {
+				if (Main.netMode == Client)
+					fromWho = r.ReadByte();
+
+				var dPlayer = Main.player[fromWho].GetModPlayer<ModAccessorySlotPlayer>();
+
+				sbyte slot = r.ReadSByte();
+				
+				dPlayer.exHideAccessory[slot] = r.ReadBoolean();
+
+				if (Main.netMode == Server)
+					SendVisualState(-1, fromWho, slot, dPlayer.exHideAccessory[slot]);
+			}
+
+			public static void HandlePacket(BinaryReader r, int fromWho) {
+				switch (r.ReadByte()) {
+					case InventorySlot:
+						HandleSlot(r, fromWho);
+						break;
+					case VisualState:
+						HandleVisualState(r, fromWho);
+						break;
+				}
+			}
+
+			public static void SetSlot(sbyte slot, Item item, ModAccessorySlotPlayer dPlayer) {
+				if (slot < 0)
+					dPlayer.exDyesAccessory[-(slot + 1)] = item;
+				else
+					dPlayer.exAccessorySlot[slot] = item;
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
@@ -3,6 +3,7 @@ using ReLogic.Content;
 using ReLogic.Content.Sources;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Terraria.ModLoader.Assets;
@@ -61,5 +62,7 @@ namespace Terraria.ModLoader.Default
 			}
 			return false;
 		}
+
+		public override void HandlePacket(BinaryReader reader, int whoAmI) => ModAccessorySlotPlayer.NetHandler.HandlePacket(reader, whoAmI);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedAccessorySlot.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedAccessorySlot.cs
@@ -1,0 +1,15 @@
+namespace Terraria.ModLoader.Default
+{
+	[Autoload(false)]
+	public class UnloadedAccessorySlot : ModAccessorySlot
+	{
+		public override string Name { get; }
+
+		internal UnloadedAccessorySlot(int slot, string oldName) {
+			Type = slot;
+			Name = oldName;
+		}
+
+		public override bool IsEnabled() => false;
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/EquipLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/EquipLoader.cs
@@ -77,7 +77,7 @@ namespace Terraria.ModLoader
 			//Sets
 			LoaderUtils.ResetStaticMembers(typeof(ArmorIDs), true);
 			WingStatsInitializer.Load();
-			
+
 			foreach (EquipType type in EquipTypes) {
 				foreach (var entry in equipTextures[type]) {
 					int slot = entry.Key;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -734,7 +734,16 @@ namespace Terraria.ModLoader
 		/// <param name="item">The item that is attepting to equip.</param>
 		/// <param name="player">The player.</param>
 		/// <param name="slot">The inventory slot that the item is attempting to occupy.</param>
-		public virtual bool CanEquipAccessory(Item item, Player player, int slot) {
+		/// <param name="modded">If the inventory slot index is for modded slots.</param>
+		public virtual bool CanEquipAccessory(Item item, Player player, int slot, bool modded) {
+			return true;
+		}
+
+		/// <summary>
+		/// Allows you to prevent similar accessories from being equipped multiple times. For example, vanilla Wings.
+		/// Return false to have the currently equipped item swapped with the incoming item - ie both can't be equipped at same time.
+		/// </summary>
+		public virtual bool CanAccessoryBeEquippedWith(Item equippedItem, Item incomingItem, Player player) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -873,7 +873,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookUpdateEquip = AddHook<Action<Item, Player>>(g => g.UpdateEquip);
 		/// <summary>
-		/// Hook at the end of Player.VanillaUpdateEquip can be called from modded slots for modded equipments
+		/// Hook at the end of Player.VanillaUpdateEquip can be called to apply additional code related to accessory slots for a particular item
 		/// </summary>
 		public static void UpdateEquip(Item item, Player player) {
 			if (item.IsAir)
@@ -888,7 +888,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookUpdateAccessory = AddHook<Action<Item, Player, bool>>(g => g.UpdateAccessory);
 		/// <summary>
-		/// Hook at the end of Player.ApplyEquipFunctional can be called from modded slots for modded equipments
+		/// Hook at the end of Player.ApplyEquipFunctional can be called to apply additional code related to accessory slots for a particular item.
 		/// </summary>
 		public static void UpdateAccessory(Item item, Player player, bool hideVisual) {
 			if (item.IsAir)
@@ -903,7 +903,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookUpdateVanity = AddHook<Action<Item, Player>>(g => g.UpdateVanity);
 		/// <summary>
-		/// Hook at the end of Player.ApplyEquipVanity can be called from modded slots for modded equipments
+		/// Hook at the end of Player.ApplyEquipVanity can be called to apply additional code related to accessory slots for a particular item
 		/// </summary>
 		public static void UpdateVanity(Item item, Player player) {
 			if (item.IsAir)
@@ -1229,6 +1229,7 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		/*
 		/// <summary>s
 		/// Returns the wing item that the player is functionally using. If player.wingsLogic has been modified, so no equipped wing can be found to match what the player is using, this creates a new Item object to return.
 		/// </summary>
@@ -1255,6 +1256,7 @@ namespace Terraria.ModLoader
 			}
 			return null;
 		}
+		*/
 
 		private delegate void DelegateVerticalWingSpeeds(Item item, Player player, ref float ascentWhenFalling, ref float ascentWhenRising, ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend);
 		private static HookList HookVerticalWingSpeeds = AddHook<DelegateVerticalWingSpeeds>(g => g.VerticalWingSpeeds);
@@ -1265,7 +1267,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public static void VerticalWingSpeeds(Player player, ref float ascentWhenFalling, ref float ascentWhenRising,
 			ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend) {
-			Item item = GetWing(player);
+			Item item = player.equippedWings;
 			if (item == null) {
 				EquipTexture texture = EquipLoader.GetEquipTexture(EquipType.Wings, player.wingsLogic);
 				texture?.VerticalWingSpeeds(
@@ -1291,13 +1293,13 @@ namespace Terraria.ModLoader
 		/// If the player is using wings, this uses the result of GetWing, and calls ModItem.HorizontalWingSpeeds then all GlobalItem.HorizontalWingSpeeds hooks.
 		/// </summary>
 		public static void HorizontalWingSpeeds(Player player) {
-			Item item = GetWing(player);
+			Item item = player.equippedWings;
 			if (item == null) {
 				EquipTexture texture = EquipLoader.GetEquipTexture(EquipType.Wings, player.wingsLogic);
 				texture?.HorizontalWingSpeeds(player, ref player.accRunSpeed, ref player.runAcceleration);
 				return;
 			}
-			
+
 			item.ModItem?.HorizontalWingSpeeds(player, ref player.accRunSpeed, ref player.runAcceleration);
 
 			foreach (var g in HookHorizontalWingSpeeds.Enumerate(item.globalItems)) {
@@ -1574,16 +1576,36 @@ namespace Terraria.ModLoader
 			origin += modOrigin;
 		}
 
-		private static HookList HookCanEquipAccessory = AddHook<Func<Item, Player, int, bool>>(g => g.CanEquipAccessory);
+		private static HookList HookCanEquipAccessory = AddHook<Func<Item, Player, int, bool, bool>>(g => g.CanEquipAccessory);
 		//in Terraria.UI.ItemSlot.AccCheck replace 2nd and 3rd return false with
 		//  return !ItemLoader.CanEquipAccessory(item, slot)
-		public static bool CanEquipAccessory(Item item, int slot) {
+		public static bool CanEquipAccessory(Item item, int slot, bool modded) {
 			Player player = Main.player[Main.myPlayer];
-			if (item.ModItem != null && !item.ModItem.CanEquipAccessory(player, slot))
+			if (item.ModItem != null && !item.ModItem.CanEquipAccessory(player, slot, modded))
 				return false;
 
 			foreach (var g in HookCanEquipAccessory.Enumerate(item.globalItems)) {
-				if (!g.CanEquipAccessory(item, player, slot))
+				if (!g.CanEquipAccessory(item, player, slot, modded))
+					return false;
+			}
+
+			return true;
+		}
+
+		private static HookList HookCanAccessoryBeEquippedWith = AddHook<Func<Item, Item, Player, bool>>(g => g.CanAccessoryBeEquippedWith);
+		public static bool CanAccessoryBeEquippedWith(Item equippedItem, Item incomingItem) {
+			Player player = Main.player[Main.myPlayer];
+			return CanAccessoryBeEquippedWith(equippedItem, incomingItem, player) && CanAccessoryBeEquippedWith(incomingItem, equippedItem, player);
+		}
+		private static bool CanAccessoryBeEquippedWith(Item equippedItem, Item incomingItem, Player player) {
+			if (equippedItem.ModItem != null && !equippedItem.ModItem.CanAccessoryBeEquippedWith(equippedItem, incomingItem, player))
+				return false;
+
+			if (incomingItem.ModItem != null && !incomingItem.ModItem.CanAccessoryBeEquippedWith(equippedItem, incomingItem, player))
+				return false;
+
+			foreach (var g in HookCanAccessoryBeEquippedWith.Enumerate(incomingItem.globalItems)) {
+				if (!g.CanAccessoryBeEquippedWith(equippedItem, incomingItem, player))
 					return false;
 			}
 
@@ -1722,7 +1744,7 @@ namespace Terraria.ModLoader
 
 			return tooltips;
 		}
-		
+
 		internal static bool NeedsModSaving(Item item) {
 			if (item.type <= ItemID.None)
 				return false;

--- a/patches/tModLoader/Terraria/ModLoader/ModAccessorySlot.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAccessorySlot.cs
@@ -1,0 +1,123 @@
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader.Default;
+using Terraria.UI;
+
+//NOTE: Does not fully support: ItemLoader.GetGamepadInstructions and related gamepad stuff.
+//TODO: Documentation?
+
+namespace Terraria.ModLoader
+{
+	/// <summary>
+	/// A ModAccessorySlot instance represents a net new accessory slot instance. You can store fields in the ModAccessorySlot class. 
+	/// </summary>
+	public abstract class ModAccessorySlot : ModType
+	{
+		public int Type { get; internal set; }
+
+		public static Player Player => Main.CurrentPlayer;
+
+		public ModAccessorySlotPlayer ModSlotPlayer => AccessorySlotLoader.ModSlotPlayer(Player);
+
+		// Properties to preset a location for the accessory slot
+		public virtual Vector2? CustomLocation => null;
+
+		// Properties to change the Default Background Texture
+		public virtual string DyeBackgroundTexture => null;
+		public virtual string VanityBackgroundTexture => null;
+		public virtual string FunctionalBackgroundTexture => null;
+
+		// Properties to change the Default Style Image Texture
+		public virtual string DyeTexture => null;
+		public virtual string VanityTexture => null;
+		public virtual string FunctionalTexture => null;
+
+		// Properties to control which parts of accessory slot draw
+		public virtual bool DrawFunctionalSlot => true;
+		public virtual bool DrawVanitySlot => true;
+		public virtual bool DrawDyeSlot => true;
+
+		// Get/Set Properties for fetching slot information
+		public Item FunctionalItem {
+			get => ModSlotPlayer.exAccessorySlot[Type];
+			set => ModSlotPlayer.exAccessorySlot[Type] = value;
+		}
+
+		public Item VanityItem {
+			get => ModSlotPlayer.exAccessorySlot[Type + ModSlotPlayer.SlotCount()];
+			set => ModSlotPlayer.exAccessorySlot[Type + ModSlotPlayer.SlotCount()] = value;
+		}
+
+		public Item DyeItem {
+			get => ModSlotPlayer.exDyesAccessory[Type];
+			set => ModSlotPlayer.exDyesAccessory[Type] = value;
+		}
+
+		public bool HideVisuals {
+			get => ModSlotPlayer.exHideAccessory[Type];
+			set => ModSlotPlayer.exHideAccessory[Type] = value;
+		}
+
+		public bool IsEmpty => FunctionalItem.IsAir && VanityItem.IsAir && DyeItem.IsAir;
+
+		// Functionality and Hooks
+		protected sealed override void Register() => Type = LoaderManager.Get<AccessorySlotLoader>().Register(this);
+
+		/// <summary>
+		/// Allows drawing prior to vanilla ItemSlot.Draw code. Return false to NOT call ItemSlot.Draw
+		/// </summary>
+		public virtual bool PreDraw(AccessorySlotType context, Item item, Vector2 position, bool isHovered) { 
+			return true; 
+		}
+
+		public virtual void PostDraw(AccessorySlotType context, Item item, Vector2 position, bool isHovered) { }
+
+		/// <summary>
+		/// Override to replace the vanilla effect behavior of the slot with your own.
+		/// By default calls:
+		/// Player.VanillaUpdateEquips(FunctionalItem), Player.ApplyEquipFunctional(FunctionalItem, ShowVisuals), Player.ApplyEquipVanity(VanityItem)
+		/// </summary>
+		public virtual void ApplyEquipEffects() {
+			Player.VanillaUpdateEquip(FunctionalItem);
+			Player.ApplyEquipFunctional(FunctionalItem, HideVisuals);
+			Player.ApplyEquipVanity(VanityItem);
+		}
+
+		/// <summary>
+		/// Override to set conditions on what can be placed in the slot. Return false to prevent the item going in slot. Return true for dyes, if you want dyes. Example: only wings can go in slot.
+		/// Receives data:
+		/// <para><paramref name="checkItem"/> :: the item that is attempting to enter the slot </para>
+		/// </summary>
+		public virtual bool CanAcceptItem(Item checkItem, AccessorySlotType context) => true;
+
+		/// <summary>
+		/// After checking for empty slots in ItemSlot.AccessorySwap, this allows for changing what the default target slot (accSlotToSwapTo) will be.
+		/// DOES NOT affect vanilla behaviour of swapping items like for like where existing in a slot
+		/// Return true to set this slot as the default targetted slot.
+		/// </summary>
+		public virtual bool ModifyDefaultSwapSlot(Item item, int accSlotToSwapTo) => false;
+
+		/// <summary>
+		/// Override to control whether or not drawing will be skipped during the given frame.
+		/// NOTE: Nothing will be drawn, nor will subsequent drawing hooks be called on this slot for the frame while true
+		/// </summary>
+		public virtual bool IsHidden() => false;
+
+		/// <summary>
+		/// Override to set conditions on when the slot is valid for stat/vanity calculations and player usage.
+		/// Example: the demonHeart is consumed and in Expert mode in Vanilla.
+		/// </summary>
+		public virtual bool IsEnabled() => true;
+
+		/// <summary>
+		/// Override to change the condition on when the slot is visible, but otherwise non-functional for stat/vanity calculations.
+		/// Defaults to check 'property' IsEmpty
+		/// </summary>
+		/// <returns></returns>
+		public virtual bool IsVisibleWhenNotEnabled() => !IsEmpty;
+
+		/// <summary>
+		/// Allows you to do stuff while the player is hovering over this slot.
+		/// </summary>
+		public virtual void OnMouseHover(AccessorySlotType context) { }
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -864,7 +864,16 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="player">The player.</param>
 		/// <param name="slot">The inventory slot that the item is attempting to occupy.</param>
-		public virtual bool CanEquipAccessory(Player player, int slot) {
+		/// <param name="modded">If the inventory slot index is for modded slots.</param>
+		public virtual bool CanEquipAccessory(Player player, int slot, bool modded) {
+			return true;
+		}
+
+		/// <summary>
+		/// Allows you to prevent similar accessories from being equipped multiple times. For example, vanilla Wings.
+		/// Return false to have the currently equipped item swapped with the incoming item - ie both can't be equipped at same time.
+		/// </summary>
+		public virtual bool CanAccessoryBeEquippedWith(Item equippedItem, Item incomingItem, Player player) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using Terraria.DataStructures;
 using Terraria.GameInput;
-using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
@@ -203,6 +202,24 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Is called in Player.Frame() after vanilla functional slots are evaluated, including selection screen to prepare and denote visible accessories. Player Instance sensitive.
+		/// </summary>
+		public virtual void UpdateVisibleAccessories() {
+		}
+
+		/// <summary>
+		/// Is called in Player.Frame() after vanilla vanity slots are evaluated, including selection screen to prepare and denote visible accessories. Player Instance sensitive.
+		/// </summary>
+		public virtual void UpdateVisibleVanityAccessories() {
+		}
+
+		/// <summary>
+		/// Is called in Player.UpdateDyes(), including selection screen. Player Instance sensitive.
+		/// </summary>
+		public virtual void UpdateDyes() {
+		}
+
+		/// <summary>
 		/// This is called after miscellaneous update code is called in Player.Update, which is sometime after PostUpdateEquips is called. This can be used for general update tasks.
 		/// </summary>
 		public virtual void PostUpdateMiscEffects() {
@@ -224,12 +241,6 @@ namespace Terraria.ModLoader
 		/// This is called at the very end of the Player.Update method. Final general update tasks can be placed here.
 		/// </summary>
 		public virtual void PostUpdate() {
-		}
-
-		/// <summary>
-		/// This is called after VanillaUpdateVanityAccessory() in player.UpdateEquips()
-		/// </summary>
-		public virtual void UpdateVanityAccessories() {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -224,19 +224,35 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static HookList HookUpdateVanityAccessories = AddHook<Action>(p => p.UpdateVanityAccessories);
-
-		public static void UpdateVanityAccessories(Player player) {
-			foreach (int index in HookUpdateVanityAccessories.arr) {
-				player.modPlayers[index].UpdateVanityAccessories();
-			}
-		}
-
 		private static HookList HookPostUpdateEquips = AddHook<Action>(p => p.PostUpdateEquips);
 
 		public static void PostUpdateEquips(Player player) {
 			foreach (int index in HookPostUpdateEquips.arr) {
 				player.modPlayers[index].PostUpdateEquips();
+			}
+		}
+
+		private static HookList HookUpdateVisibleAccessories = AddHook<Action>(p => p.UpdateVisibleAccessories);
+
+		public static void UpdateVisibleAccessories(Player player) {
+			foreach (int index in HookUpdateVisibleAccessories.arr) {
+				player.modPlayers[index].UpdateVisibleAccessories();
+			}
+		}
+
+		private static HookList HookUpdateVisibleVanityAccessories = AddHook<Action>(p => p.UpdateVisibleVanityAccessories);
+
+		public static void UpdateVisibleVanityAccessories(Player player) {
+			foreach (int index in HookUpdateVisibleVanityAccessories.arr) {
+				player.modPlayers[index].UpdateVisibleVanityAccessories();
+			}
+		}
+
+		private static HookList HookUpdateDyes = AddHook<Action>(p => p.UpdateDyes);
+
+		public static void UpdateDyes(Player player) {
+			foreach (int index in HookUpdateDyes.arr) {
+				player.modPlayers[index].UpdateDyes();
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Xna.Framework;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,7 @@ namespace Terraria
 	{
 		internal IList<string> usedMods;
 		internal ModPlayer[] modPlayers = Array.Empty<ModPlayer>();
+		public Item equippedWings = null;
 
 		public HashSet<int> NearbyModTorch { get; private set; } = new HashSet<int>();
 
@@ -138,6 +140,83 @@ namespace Terraria
 			bool three = ZoneLihzhardTemple || ZoneMarble || ZoneMeteor || ZoneSnow || ZoneUnderworldHeight;
 			bool four = modBiomeFlags.Cast<bool>().Contains(true);
 			return !(one || two || three || four);
+		}
+
+		/// <summary>
+		/// Invoked at the end of loading vanilla player data from files to fix stuff that isn't initialized coming out of load.
+		/// Only run on the Player select screen during loading of data. 
+		/// Primarily meant to prevent unwarranted first few frame fall damage/lava damage if load lagging
+		/// Corrects the player.lavaMax time, wingsLogic, and no fall dmg to be accurate for the provided items in accessory slots.
+		/// </summary>
+		public static void LoadPlayer_LastMinuteFixes(Item item, Player newPlayer) {
+			int type = item.type;
+			if (type == 908 || type == 4874 || type == 5000)
+				newPlayer.lavaMax += 420;
+
+			if (type == 906 || type == 4038)
+				newPlayer.lavaMax += 420;
+
+			if (newPlayer.wingsLogic == 0 && item.wingSlot >= 0) {
+				newPlayer.wingsLogic = item.wingSlot;
+				newPlayer.equippedWings = item;
+			}
+
+			if (type == 158 || type == 396 || type == 1250 || type == 1251 || type == 1252)
+				newPlayer.noFallDmg = true;
+
+			newPlayer.lavaTime = newPlayer.lavaMax;
+		}
+
+		/// <summary>
+		/// Invoked in UpdateVisibleAccessories. Runs common code for both modded slots and vanilla slots based on provided Items.
+		/// </summary>
+		public void UpdateVisibleAccessories(Item item, bool invisible, int slot = -1, bool modded = false) {
+			if (eocDash > 0 && shield == -1 && item.shieldSlot != -1) {
+				shield = item.shieldSlot;
+				if (cShieldFallback != -1)
+					cShield = cShieldFallback;
+			}
+
+			if (shieldRaised && shield == -1 && item.shieldSlot != -1) {
+				shield = item.shieldSlot;
+				if (cShieldFallback != -1)
+					cShield = cShieldFallback;
+			}
+
+			if (ItemIsVisuallyIncompatible(item))
+				return;
+
+			if (item.wingSlot > 0) {
+				if (invisible && (velocity.Y == 0f || mount.Active))
+					return;
+
+				wings = item.wingSlot;
+			}
+
+			if (!invisible)
+				UpdateVisibleAccessory(slot, item, modded);
+		}
+
+		/// <summary>
+		/// Drops the ref'd item from the player at the position, and than turns the ref'd Item to air.
+		/// </summary>
+		public void DropItem(Vector2 position, ref Item item) {
+			if (item.stack > 0) {
+				int num3 = Item.NewItem((int)position.X, (int)position.Y, width, height, item.type);
+				Main.item[num3].netDefaults(item.netID);
+				Main.item[num3].Prefix(item.prefix);
+				Main.item[num3].stack = item.stack;
+				Main.item[num3].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
+				Main.item[num3].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
+				Main.item[num3].noGrabDelay = 100;
+				Main.item[num3].newAndShiny = false;
+				Main.item[num3].ModItem = item.ModItem;
+				Main.item[num3].globalItems = item.globalItems;
+				if (Main.netMode == 1)
+					NetMessage.SendData(21, -1, -1, null, num3);
+			}
+
+			item.TurnToAir();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -67,7 +67,7 @@
  		public int[] builderAccStatus = new int[12] {
  			1,
  			0,
-@@ -430,15 +_,15 @@
+@@ -430,8 +_,8 @@
  		private static SlotId _insideBlizzardSound = SlotId.Invalid;
  		public string name = "";
  		public int taxMoney;
@@ -78,14 +78,6 @@
  		public static int crystalLeafDamage = 100;
  		public static int crystalLeafKB = 10;
  		public float basiliskCharge;
- 		public Vector2 lastDeathPostion;
- 		public DateTime lastDeathTime;
- 		public bool showLastDeath;
--		public int extraAccessorySlots = 2;
-+		private int extraAccessorySlots; //unused vanilla field, noob trap
- 		public bool extraAccessory;
- 		private bool dontConsumeWand;
- 		public int tankPet = -1;
 @@ -694,7 +_,7 @@
  		public bool poundRelease;
  		public float ghostFade;
@@ -929,6 +921,20 @@
  		}
  
  		public void UpdateDyes() {
+@@ -6382,11 +_,12 @@
+ 					UpdateItemDye(i < 10, hideVisibleAccessory[num], armor[i], dye[num]);
+ 				}
+ 			}
++			PlayerLoader.UpdateDyes(this);
+ 
+ 			cYorai = cPet;
+ 		}
+ 
+-		private void UpdateItemDye(bool isNotInVanitySlot, bool isSetToHidden, Item armorItem, Item dyeItem) {
++		internal void UpdateItemDye(bool isNotInVanitySlot, bool isSetToHidden, Item armorItem, Item dyeItem) {
+ 			if (armorItem.IsAir)
+ 				return;
+ 
 @@ -6398,13 +_,13 @@
  			if (!num && flag)
  				return;
@@ -1646,7 +1652,7 @@
  			for (int m = 3; m < 10; m++) {
  				if (armor[m].wingSlot > 0 && IsAValidEquipmentSlotForIteration(m)) {
  					if (!hideVisibleAccessory[m] || (velocity.Y != 0f && !mount.Active))
-@@ -9342,12 +_,15 @@
+@@ -9342,6 +_,7 @@
  					wingsLogic = armor[m].wingSlot;
  				}
  			}
@@ -1654,14 +1660,6 @@
  
  			for (int n = 13; n < 20; n++) {
  				if (IsAValidEquipmentSlotForIteration(n))
- 					ApplyEquipVanity(n, armor[n]);
- 			}
- 
-+			PlayerLoader.UpdateVanityAccessories(this);
-+
- 			if (wet && ShouldFloatInWater)
- 				accFlipper = true;
- 
 @@ -9519,6 +_,10 @@
  		}
  
@@ -1770,19 +1768,30 @@
  			}
  
  			if (currentItem.wingSlot != -1)
-@@ -10415,9 +_,9 @@
+@@ -10414,10 +_,20 @@
+ 				manaCost -= 0.08f;
  			}
  
++			if (currentItem.wingSlot > 0) {
++				if (!hideVisibleAccessory[itemSlot] || velocity.Y != 0f && !mount.Active)
++					wings = currentItem.wingSlot;
++
++				wingsLogic = currentItem.wingSlot;
++				equippedWings = currentItem;
++			}
++
++			ItemLoader.UpdateAccessory(currentItem, this, hideVisual);
++
  			if (Main.myPlayer != whoAmI)
 -				return;
-+				return; // TODO: double check wings logic, etc.
++				return; // return early if sounds are not relevant
  
 -			if (currentItem.type == 576 && Main.rand.Next(540) == 0 && Main.curMusic > 0 && Main.curMusic <= 90) {
 +			if (currentItem.type == 576 && Main.rand.Next(540) == 0 && Main.curMusic > 0) {
  				SoundEngine.PlaySound(SoundID.Item166, base.Center);
  				int num3 = -1;
  				if (Main.curMusic == 1)
-@@ -10579,13 +_,26 @@
+@@ -10579,10 +_,14 @@
  					currentItem.SetDefaults(5040);
  				else if (Main.curMusic == 89)
  					currentItem.SetDefaults(5044);
@@ -1798,18 +1807,6 @@
  			}
  
  			ApplyMusicBox(currentItem);
-+
-+			if (currentItem.wingSlot > 0) {
-+				if (!hideVisibleAccessory[itemSlot] || velocity.Y != 0f && !mount.Active)
-+					wings = currentItem.wingSlot;
-+
-+				wingsLogic = currentItem.wingSlot;
-+			}
-+
-+			ItemLoader.UpdateAccessory(currentItem, this, hideVisual);
- 		}
- 
- 		private void ApplyMusicBox(Item currentItem) {
 @@ -10772,6 +_,9 @@
  			if (currentItem.type == 5044)
  				Main.musicBox2 = 85;
@@ -1977,6 +1974,14 @@
  		}
  
  		public void UpdateDead() {
+@@ -11900,6 +_,7 @@
+ 			ResetFloorFlags();
+ 			wings = 0;
+ 			wingsLogic = 0;
++			equippedWings = null;
+ 			ResetVisibleAccessories();
+ 			poisoned = false;
+ 			venom = false;
 @@ -11941,8 +_,9 @@
  			hasGingerBeard = false;
  			hasRainbowCursor = false;
@@ -2126,6 +2131,14 @@
  			coolWhipBuff = false;
  			yoraiz0rEye = 0;
  			yoraiz0rDarkness = false;
+@@ -13041,6 +_,7 @@
+ 			slowOgreSpit = false;
+ 			wings = 0;
+ 			wingsLogic = 0;
++			equippedWings = null;
+ 			wingTimeMax = 0;
+ 			brokenArmor = false;
+ 			silence = false;
 @@ -13145,17 +_,19 @@
  				}
  			}
@@ -2425,6 +2438,15 @@
  				if (!Falling) {
  					float num3 = Math.Abs(velocity.X) / 3f;
  					if ((float)Main.rand.Next(100) > num3 * 100f)
+@@ -16811,6 +_,8 @@
+ 		}
+ 
+ 		public void Update(int i) {
++			using var _currentPlr = new Main.CurrentPlayerOverride(this);
++
+ 			if (i == Main.myPlayer && Main.netMode != 2)
+ 				LockOnHelper.Update();
+ 
 @@ -16961,6 +_,7 @@
  
  			UpdateHairDyeDust();
@@ -2479,7 +2501,7 @@
  						}
  					}
 -					else if (((gravDir == 1f && num18 > num17) || (gravDir == -1f && num18 < -num17)) && !noFallDmg && !flag12) {
-+					else if (((gravDir == 1f && num18 > num17) || (gravDir == -1f && num18 < -num17)) && !noFallDmg && wingsLogic == 0) {
++					else if (((gravDir == 1f && num18 > num17) || (gravDir == -1f && num18 < -num17)) && !noFallDmg && equippedWings == null) {
  						immune = false;
  						int num25 = (int)((float)num18 * gravDir - (float)num17) * 10;
  						if (mount.Active)
@@ -3079,6 +3101,17 @@
  				if (oldAdjTile[l] != adjTile[l]) {
  					flag = true;
  					break;
+@@ -25059,8 +_,9 @@
+ 			if (armor[12].legSlot >= 0)
+ 				legs = armor[12].legSlot;
+ 
+-			if (!dead)
++			if (!dead) {
+ 				UpdateVisibleAccessories();
++			}
+ 
+ 			wearsRobe = false;
+ 			bool somethingSpecial = false;
 @@ -25201,6 +_,7 @@
  				faceHead = -1;
  			}
@@ -3125,6 +3158,39 @@
  			if (legs == 140) {
  				legFrameCounter = 0.0;
  				legFrame.Y = legFrame.Height * (velocity.Y != 0f).ToInt();
+@@ -25789,6 +_,7 @@
+ 		}
+ 
+ 		private void UpdateVisibleAccessories() {
++			/*
+ 			for (int i = 3; i < 10; i++) {
+ 				if (!IsAValidEquipmentSlotForIteration(i))
+ 					continue;
+@@ -25827,6 +_,24 @@
+ 						UpdateVisibleAccessory(j, item2);
+ 				}
+ 			}
++			*/
++			for (int i = 3; i < 10; i++) {
++				if (!IsAValidEquipmentSlotForIteration(i))
++					continue;
++
++				UpdateVisibleAccessories(armor[i], hideVisibleAccessory[i], i);
++			}
++
++			PlayerLoader.UpdateVisibleAccessories(this);
++
++			for (int i = 13; i < 20; i++) {
++				if (!IsAValidEquipmentSlotForIteration(i))
++					continue;
++
++				UpdateVisibleAccessory(i, armor[i]);
++			}
++
++			PlayerLoader.UpdateVisibleVanityAccessories(this);
+ 
+ 			if (HeldItem.type == 4760 && ownedProjectileCounts[866] < 1) {
+ 				shield = 9;
 @@ -25834,7 +_,7 @@
  			}
  		}
@@ -3134,19 +3200,33 @@
  			if (compositeBackArm.enabled && item.shieldSlot > 0)
  				return true;
  
-@@ -25860,6 +_,12 @@
+@@ -25860,7 +_,7 @@
  			return false;
  		}
  
-+		/// <summary>
-+		/// Won't work with yoraiz0rEye as effect needs target item slot.
-+		/// </summary>
-+		/// <param name="item"></param>
-+		public void UpdateVisibleAccessory(Item item) => UpdateVisibleAccessory(-1, item);
-+
- 		private void UpdateVisibleAccessory(int itemSlot, Item item) {
+-		private void UpdateVisibleAccessory(int itemSlot, Item item) {
++		public void UpdateVisibleAccessory(int itemSlot, Item item, bool modded = false) {
  			if (item.stringColor > 0)
  				stringColor = item.stringColor;
+ 
+@@ -25923,8 +_,15 @@
+ 			if (item.wingSlot > 0)
+ 				wings = item.wingSlot;
+ 
+-			if (item.type == 3580)
+-				yoraiz0rEye = itemSlot - 2;
++			if (item.type == 3580) {
++				if (modded) {
++					// Treat similar to expert/master mode slots
++					yoraiz0rEye = 5 + itemSlot - 2;
++				}
++				else {
++					yoraiz0rEye = itemSlot - 2;
++				}
++			}
+ 
+ 			if (item.type == 3581)
+ 				yoraiz0rDarkness = true;
 @@ -26082,6 +_,8 @@
  			if (drawPlayer.head == 267)
  				yoraiz0rDarkness = true;
@@ -3183,6 +3263,14 @@
  				if (buffTime[i] > 0 && buffType[i] == 59)
  					DelBuff(i);
  			}
+@@ -26699,6 +_,7 @@
+ 				NetMessage.SendData(62, -1, -1, null, whoAmI, 1f);
+ 		}
+ 
++		//TODO: what does this method accomplish? Just determining frost and bone armor?
+ 		public void ApplyArmorSoundAndDustChanges() {
+ 			int num = armor[0].headSlot;
+ 			int num2 = armor[1].bodySlot;
 @@ -26761,6 +_,12 @@
  					return 0.0;
  				}
@@ -4133,6 +4221,16 @@
  			Vector2 pointPoisition = Main.MouseWorld;
  			pointPoisition += offsetFromCursor;
  			LimitPointToPlayerReachableArea(ref pointPoisition);
+@@ -34132,6 +_,9 @@
+ 				return;
+ 			}
+ 
++			if (LoaderManager.Get<AccessorySlotLoader>().PreferredGolfBall(ref projType))
++				return;
++
+ 			for (int num = 19; num >= 0; num--) {
+ 				if (IsAValidEquipmentSlotForIteration(num)) {
+ 					_ = num % 10;
 @@ -34164,6 +_,11 @@
  		private void ItemCheck_MinionAltFeatureUse(Item sItem, bool cShoot) {
  			if (sItem.shoot > 0 && ProjectileID.Sets.MinionTargettingFeature[sItem.shoot] && altFunctionUse == 2 && cShoot && ItemTimeIsZero) {
@@ -4513,7 +4611,7 @@
  
  			if (tileTarget.type == 147 || tileTarget.type == 0 || tileTarget.type == 40 || tileTarget.type == 53 || tileTarget.type == 57 || tileTarget.type == 59 || tileTarget.type == 123 || tileTarget.type == 224 || tileTarget.type == 397)
  				num += pickPower;
-@@ -37121,24 +_,47 @@
+@@ -37121,24 +_,50 @@
  		}
  
  		public void DropItems() {
@@ -4526,6 +4624,9 @@
 +
 +				startCounts[item.netID] += item.stack;
 +			}
++
++			//TML: Drop code for modded accessory Slots, should run prior to dropping other items in case conditions are used based on player's current equips
++			AccessorySlotLoader.ModSlotPlayer(this).DropItems();
 +
 +			startCounts[ModContent.ItemType<ModLoader.Default.StartBag>()] = 1;
  			for (int i = 0; i < 59; i++) {
@@ -4790,6 +4891,15 @@
  		}
  
  		private void SaveTemporaryItemSlotContents(BinaryWriter writer) {
+@@ -37745,6 +_,8 @@
+ 				Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
+ 
+ 			Player player = new Player();
++			using var _currentPlr = new Main.CurrentPlayerOverride(player);
++
+ 			try {
+ 				RijndaelManaged rijndaelManaged = new RijndaelManaged();
+ 				rijndaelManaged.Padding = PaddingMode.None;
 @@ -38083,7 +_,7 @@
  							if (num >= 11) {
  								int num28 = 22;
@@ -4818,21 +4928,42 @@
  			catch {
  			}
  
-@@ -38213,8 +_,9 @@
+@@ -38213,9 +_,12 @@
  			}
  		}
  
 -		private static void LoadPlayer_LastMinuteFixes(Player newPlayer) {
-+		private static void LoadPlayer_LastMinuteFixes(Player newPlayer, PlayerFileData playerFileData) {
++		public static void LoadPlayer_LastMinuteFixes(Player newPlayer, PlayerFileData playerFileData) {
  			newPlayer.skinVariant = (int)MathHelper.Clamp(newPlayer.skinVariant, 0f, 11f);
 +			PlayerIO.Load(newPlayer, playerFileData.Path, playerFileData.IsCloudSave);
  			for (int i = 3; i < 10; i++) {
++				LoadPlayer_LastMinuteFixes(newPlayer.armor[i], newPlayer);
++				/*
  				int type = newPlayer.armor[i].type;
  				if (type == 908 || type == 4874 || type == 5000)
-@@ -38231,6 +_,7 @@
+ 					newPlayer.lavaMax += 420;
+@@ -38223,14 +_,24 @@
+ 				if (type == 906 || type == 4038)
+ 					newPlayer.lavaMax += 420;
+ 
+-				if (newPlayer.wingsLogic == 0 && newPlayer.armor[i].wingSlot >= 0)
++				if (newPlayer.wingsLogic == 0 && newPlayer.armor[i].wingSlot >= 0) {
+ 					newPlayer.wingsLogic = newPlayer.armor[i].wingSlot;
++					newPlayer.equippedWings = newPlayer.armor[i];
++				}
+ 
+ 				if (type == 158 || type == 396 || type == 1250 || type == 1251 || type == 1252)
+ 					newPlayer.noFallDmg = true;
  
  				newPlayer.lavaTime = newPlayer.lavaMax;
++				*/
  			}
++
++			var modSlotPlayer = AccessorySlotLoader.ModSlotPlayer(newPlayer);
++			for (int i = 0; i < modSlotPlayer.SlotCount(); i++) {
++				LoadPlayer_LastMinuteFixes(modSlotPlayer.exAccessorySlot[i], newPlayer);
++			}
++
 +			newPlayer.ResetEffects();
  		}
  

--- a/patches/tModLoader/Terraria/UI/ItemSlot.TML.cs
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.TML.cs
@@ -1,0 +1,169 @@
+using System;
+using Terraria.Audio;
+using Terraria.ModLoader;
+
+namespace Terraria.UI
+{
+	public partial class ItemSlot
+	{
+		private static bool AccessorySwap(Player player, Item item, ref Item result) {
+			//TML: Rewrote ArmorSwap for accessories under the PR #1299 so it was actually readable. No vanilla functionality lost in transition
+			accSlotToSwapTo = -1;
+			var accLoader = LoaderManager.Get<AccessorySlotLoader>();
+			var accessories = AccessorySlotLoader.ModSlotPlayer(player).exAccessorySlot;
+
+			//TML: Check if there is an empty slot available in functional slots, and if not, track the last available slot
+			for (int i = 3; i < 10; i++) {
+				if (player.IsAValidEquipmentSlotForIteration(i)) {
+					if (player.armor[i].type == 0 && ItemLoader.CanEquipAccessory(item, i, false)) {
+						accSlotToSwapTo = i - 3;
+						break;
+					}
+				}
+			}
+
+			//TML: Check our modded functional slots
+			if (accSlotToSwapTo < 0) {
+				for (int i = 0; i < accessories.Length / 2; i++) {
+					if (accLoader.ModdedIsAValidEquipmentSlotForIteration(i, player)) {
+						if (accessories[i].type == 0 && accLoader.CanAcceptItem(i, item, (int)ItemSlotContext.ModdedAccessorySlot) && ItemLoader.CanEquipAccessory(item, i, true)) {
+							accSlotToSwapTo = i + 20;
+							break;
+						}
+					}
+				}
+			}
+
+			accLoader.ModifyDefaultSwapSlot(item, ref accSlotToSwapTo);
+
+			accSlotToSwapTo = Math.Max(accSlotToSwapTo, 0);
+
+			//TML: Check if there is an existing copy of the item in any slot (including vanity)
+			// Will also replace wings with wings
+			for (int j = 0; j < player.armor.Length; j++) {
+				if (item.IsTheSameAs(player.armor[j]) && ItemLoader.CanEquipAccessory(item, j, false))
+					accSlotToSwapTo = j - 3;
+
+				if (j < 10 && (item.wingSlot > 0 && player.armor[j].wingSlot > 0 || !ItemLoader.CanAccessoryBeEquippedWith(player.armor[j], item)) && ItemLoader.CanEquipAccessory(item, j, false))
+					accSlotToSwapTo = j - 3;
+			}
+
+			//TML: Do the same check for our modded slots
+			for (int j = 0; j < accessories.Length; j++) {
+				if (item.IsTheSameAs(accessories[j]) && accLoader.CanAcceptItem(j, item, j < accessories.Length / 2 ? (int)ItemSlotContext.ModdedAccessorySlot : (int)ItemSlotContext.ModdedVanityAccessorySlot) && ItemLoader.CanEquipAccessory(item, j, true))
+					accSlotToSwapTo = j + 20;
+
+				if (j < accLoader.list.Count && (item.wingSlot > 0 && accessories[j].wingSlot > 0 || !ItemLoader.CanAccessoryBeEquippedWith(accessories[j], item)) 
+					&& accLoader.CanAcceptItem(j, item, j < accessories.Length / 2 ? (int)ItemSlotContext.ModdedAccessorySlot : (int)ItemSlotContext.ModdedVanityAccessorySlot) && ItemLoader.CanEquipAccessory(item, j, true))
+					accSlotToSwapTo = j + 20;
+			}
+
+			if (accSlotToSwapTo >= 20) {
+				int num3 = accSlotToSwapTo - 20;
+				if (isEquipLocked(accessories[num3].type)) {
+					result =  item;
+					return false;
+				}
+					
+
+				result = accessories[num3].Clone();
+				accessories[num3] = item.Clone();
+			}
+			else {
+				int num3 = 3 + accSlotToSwapTo;
+				if (isEquipLocked(player.armor[num3].type)) {
+					result = item;
+					return false;
+				}
+
+				result = player.armor[num3].Clone();
+				player.armor[num3] = item.Clone();
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Alters the ItemSlot.DyeSwap method for modded slots; 
+		/// Unfortunately, I (Solxan) couldn't ever get ItemSlot.DyeSwap invoked so pretty sure this and its vanilla code is defunct.
+		/// Here in case someone proves my statement wrong later.
+		/// </summary>
+		private static Item ModSlotDyeSwap(Item item, out bool success) {
+			Item item2 = item;
+			var msPlayer = AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer);
+			int dyeSlotCount = 0;
+			var dyes = msPlayer.exDyesAccessory;
+
+			for (int i = 0; i < dyeSlotCount; i++) {
+				if (dyes[i].type == 0) {
+					dyeSlotCount = i;
+					break;
+				}
+			}
+
+			if (dyeSlotCount >= msPlayer.SlotCount()) {
+				success = false;
+				return item2;
+			}
+
+			item2 = dyes[dyeSlotCount].Clone();
+			dyes[dyeSlotCount] = item.Clone();
+
+			SoundEngine.PlaySound(7);
+			Recipe.FindRecipes();
+			success = true;
+			return item2;
+		}
+
+		/// <summary>
+		/// Returns true to disallow putting an item in to a given slot, typically invoked by mouse placement
+		/// </summary>
+		internal static bool AccCheck_Inner(Item[] itemCollection, Item item, int slot) {
+			if (isEquipLocked(item.type))
+				return true;
+
+			if (slot != -1) {
+				if (itemCollection[slot].IsTheSameAs(item))
+					return false;
+
+				if (itemCollection[slot].wingSlot > 0 && item.wingSlot > 0 || !ItemLoader.CanAccessoryBeEquippedWith(itemCollection[slot], item))
+					return !ItemLoader.CanEquipAccessory(item, slot, slot >= 20);
+			}
+
+			var modSlotPlayer = AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer);
+			var modCount = modSlotPlayer.SlotCount();
+			bool targetVanity = slot >= 20 && (slot >= modCount + 20) || slot < 20 && slot >= 10;
+
+			for (int i = targetVanity ? 13 : 3; i < (targetVanity ? 20 : 10); i++) {
+				if (item.wingSlot > 0 && itemCollection[i].wingSlot > 0 || !ItemLoader.CanAccessoryBeEquippedWith(itemCollection[i], item))
+					return true;
+			}
+
+			for (int i = (targetVanity ? modCount : 0) + 20; i < (targetVanity ? modCount * 2 : modCount) + 20; i++) {
+				if (item.wingSlot > 0 && itemCollection[i].wingSlot > 0 || !ItemLoader.CanAccessoryBeEquippedWith(itemCollection[i], item))
+					return true;
+			}
+
+			for (int i = 0; i < itemCollection.Length; i++) {
+				if (item.IsTheSameAs(itemCollection[i]))
+					return true;
+			}
+
+			return !ItemLoader.CanEquipAccessory(item, slot, slot >= 20);
+		}
+	}
+
+	//TODO: This is a work in progress enumerable table for Item Slot context variable. Mostly for sanity for anyone wondering. Added to as figured out.
+	public enum ItemSlotContext
+	{
+		ModdedAccessorySlot = -10,
+		ModdedVanityAccessorySlot = -11,
+		ModdedDyeSlot = -12,
+		Mouse = 0,
+		ArmorSlot = 8,
+		VanitySlot = 9,
+		AccessorySlot = 10,
+		VanityAccessorySlot = 11,
+		DyeSlot = 12
+	}
+}

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -8,7 +8,7 @@
  using Terraria.Audio;
  using Terraria.DataStructures;
  using Terraria.GameContent;
-@@ -10,6 +_,7 @@
+@@ -10,12 +_,13 @@
  using Terraria.GameInput;
  using Terraria.ID;
  using Terraria.Localization;
@@ -16,6 +16,13 @@
  using Terraria.UI.Chat;
  using Terraria.UI.Gamepad;
  
+ namespace Terraria.UI
+ {
+-	public class ItemSlot
++	public partial class ItemSlot
+ 	{
+ 		public class Options
+ 		{
 @@ -61,7 +_,7 @@
  
  		public static bool DrawGoldBGForCraftingMaterial;
@@ -25,7 +32,15 @@
  		private static bool[] canFavoriteAt;
  		private static bool[] canShareAt;
  		private static float[] inventoryGlowHue;
-@@ -352,6 +_,10 @@
+@@ -345,13 +_,17 @@
+ 		}
+ 
+ 		private static bool OverrideLeftClick(Item[] inv, int context = 0, int slot = 0) {
+-			if (context == 10 && isEquipLocked(inv[slot].type))
++			if ((context == 10 || context == -10) && isEquipLocked(inv[slot].type))
+ 				return true;
+ 
+ 			if (Main.LocalPlayer.tileEntityAnchor.IsInValidUseTileEntity() && Main.LocalPlayer.tileEntityAnchor.GetTileEntity().OverrideItemSlotLeftClick(inv, context, slot))
  				return true;
  
  			Item item = inv[slot];
@@ -36,6 +51,108 @@
  			if (Main.cursorOverride == 2) {
  				if (ChatManager.AddChatText(FontAssets.MouseText.Value, ItemTagHandler.GenerateTag(item), Vector2.One))
  					SoundEngine.PlaySound(12);
+@@ -360,7 +_,7 @@
+ 			}
+ 
+ 			if (Main.cursorOverride == 3) {
+-				if (!canFavoriteAt[context])
++				if (context < 0 || !canFavoriteAt[context])
+ 					return false;
+ 
+ 				item.favorited = !item.favorited;
+@@ -441,8 +_,13 @@
+ 				case 0:
+ 					if (context == 6 && Main.mouseItem.type != 0)
+ 						inv[slot].SetDefaults();
++					if (new int[6] { -10, -11, -12, 10, 11, 12 }.Contains(context) && !ItemLoader.CanEquipAccessory(inv[slot], slot, context < 0))
++						break;
+-					if (context == 11 && !inv[slot].FitsAccessoryVanitySlot)
++					if (Math.Abs(context) == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
+ 						break;
++					if (context < 0 && !LoaderManager.Get<AccessorySlotLoader>().CanAcceptItem(slot, inv[slot], context))
++						break;
++
+ 					Utils.Swap(ref inv[slot], ref Main.mouseItem);
+ 					if (inv[slot].stack > 0) {
+ 						switch (context) {
+@@ -451,6 +_,9 @@
+ 								break;
+ 							case 8:
+ 							case 9:
++							case -10:
++							case -11:
++							case -12:
+ 							case 10:
+ 							case 11:
+ 							case 12:
+@@ -489,6 +_,13 @@
+ 					break;
+ 				case 1:
+ 					if (Main.mouseItem.stack == 1 && Main.mouseItem.type > 0 && inv[slot].type > 0 && inv[slot].IsNotTheSameAs(Main.mouseItem) && (context != 11 || Main.mouseItem.FitsAccessoryVanitySlot)) {
++						if (new int[6] { -10, -11, -12, 10, 11, 12 }.Contains(context) && !ItemLoader.CanEquipAccessory(Main.mouseItem, slot, context < 0))
++							break;
++						if (Math.Abs(context) == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
++							break;
++						if (context < 0 && !LoaderManager.Get<AccessorySlotLoader>().CanAcceptItem(slot, Main.mouseItem, context))
++							break;
++
+ 						Utils.Swap(ref inv[slot], ref Main.mouseItem);
+ 						SoundEngine.PlaySound(7);
+ 						if (inv[slot].stack > 0) {
+@@ -498,6 +_,9 @@
+ 									break;
+ 								case 8:
+ 								case 9:
++								case -10:
++								case -11:
++								case -12:
+ 								case 10:
+ 								case 11:
+ 								case 12:
+@@ -524,6 +_,13 @@
+ 						}
+ 					}
+ 					else if (Main.mouseItem.type > 0 && inv[slot].type == 0 && (context != 11 || Main.mouseItem.FitsAccessoryVanitySlot)) {
++						if (new int[6] { -10, -11, -12, 10, 11, 12 }.Contains(context) && !ItemLoader.CanEquipAccessory(Main.mouseItem, slot, context < 0))
++							break;
++						if (Math.Abs(context) == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
++							break;
++						if (context < 0 && !LoaderManager.Get<AccessorySlotLoader>().CanAcceptItem(slot, Main.mouseItem, context))
++							break;
++
+ 						if (Main.mouseItem.stack == 1) {
+ 							Utils.Swap(ref inv[slot], ref Main.mouseItem);
+ 							if (inv[slot].type == 0 || inv[slot].stack < 1)
+@@ -551,6 +_,9 @@
+ 									break;
+ 								case 8:
+ 								case 9:
++								case -10:
++								case -11:
++								case -12:
+ 								case 10:
+ 								case 11:
+ 								case 12:
+@@ -579,6 +_,9 @@
+ 									break;
+ 								case 8:
+ 								case 9:
++								case -10:
++								case -11:
++								case -12:
+ 								case 10:
+ 								case 11:
+ 								case 12:
+@@ -632,6 +_,9 @@
+ 									break;
+ 								case 8:
+ 								case 9:
++								case -10:
++								case -11:
++								case -12:
+ 								case 10:
+ 								case 11:
+ 								case 12:
 @@ -651,18 +_,24 @@
  					break;
  				case 3:
@@ -63,6 +180,24 @@
  						}
  
  						Recipe.FindRecipes();
+@@ -686,7 +_,7 @@
+ 			bool flag = false;
+ 			bool result = false;
+ 			if (NotUsingGamepad && Options.DisableLeftShiftTrashCan) {
+-				if ((uint)context <= 4u || context == 7)
++				if ((uint)context <= 4u && context >= 0 || context == 7)
+ 					flag = true;
+ 
+ 				if (ControlInUse && flag) {
+@@ -695,7 +_,7 @@
+ 				}
+ 			}
+ 			else {
+-				if ((uint)context <= 4u)
++				if ((uint)context <= 4u && context >= 0)
+ 					flag = (Main.player[Main.myPlayer].chest == -1);
+ 
+ 				if (ShiftInUse && flag) {
 @@ -714,18 +_,20 @@
  
  			if (Main.npcShop > 0 && !inv[slot].favorited) {
@@ -87,6 +222,33 @@
  					}
  				}
  			}
+@@ -861,7 +_,12 @@
+ 						result = 1;
+ 					break;
+ 				case 10:
+-					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor, checkItem, slot)))
++					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor.Concat(AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer).exAccessorySlot).ToArray(), checkItem, slot)))
++						result = 1;
++					break;
++				case -10:
++				case -11:
++					if (checkItem.type == 0 || (checkItem.accessory && LoaderManager.Get<AccessorySlotLoader>().ModSlotCheck(checkItem, slot, context)))
+ 						result = 1;
+ 					break;
+ 				case 24:
+@@ -869,10 +_,11 @@
+ 						result = 1;
+ 					break;
+ 				case 11:
+-					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor, checkItem, slot)))
++					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor.Concat(AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer).exAccessorySlot).ToArray(), checkItem, slot)))
+ 						result = 1;
+ 					break;
+ 				case 12:
++				case -12:
+ 				case 25:
+ 				case 27:
+ 					result = 2;
 @@ -1000,10 +_,12 @@
  			switch (context) {
  				case 0:
@@ -172,7 +334,7 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1162,6 +_,9 @@
+@@ -1162,11 +_,15 @@
  
  						Recipe.FindRecipes();
  					}
@@ -182,15 +344,52 @@
  					else {
  						result = false;
  					}
-@@ -1187,7 +_,7 @@
+ 					break;
+ 				case 9:
++				case -11:
+ 				case 11: {
+ 						result = true;
+ 						if (!Main.mouseRight || !Main.mouseRightRelease)
+@@ -1175,22 +_,25 @@
+ 						if (Main.npcShop > 0)
+ 							return true;
+ 
++						//TML: Going to swap an accessory from the vanity slot in to the functional slot
++						int tSlot = slot - inv.Length / 2;
++
+-						if ((inv[slot].type <= 0 || inv[slot].stack <= 0) && (inv[slot - 10].type <= 0 || inv[slot - 10].stack <= 0))
++						if ((inv[slot].type <= 0 || inv[slot].stack <= 0) && (inv[tSlot].type <= 0 || inv[tSlot].stack <= 0))
+ 							break;
+ 
+-						Item item = inv[slot - 10];
++						Item item = inv[tSlot];
+ 						bool flag2 = context != 11 || item.FitsAccessoryVanitySlot || item.IsAir;
+ 						if (flag2 && context == 11 && inv[slot].wingSlot > 0) {
+-							for (int i = 3; i < 10; i++) {
+-								if (inv[i].wingSlot > 0 && i != slot - 10)
++							for (int i = 0; i < inv.Length / 2; i++) {
++								if (inv[i].wingSlot > 0 && i != tSlot || !ItemLoader.CanAccessoryBeEquippedWith(inv[tSlot], inv[i]))
+ 									flag2 = false;
  							}
  						}
  
 -						if (!flag2)
-+						if (!flag2 || !ItemLoader.CanEquipAccessory(inv[slot], slot - 10))
++						if (!flag2 || !ItemLoader.CanEquipAccessory(inv[slot], tSlot, context < 0))
  							break;
  
- 						Utils.Swap(ref inv[slot], ref inv[slot - 10]);
+-						Utils.Swap(ref inv[slot], ref inv[slot - 10]);
++						Utils.Swap(ref inv[slot], ref inv[tSlot]);
+ 						SoundEngine.PlaySound(7);
+ 						Recipe.FindRecipes();
+ 						if (inv[slot].stack > 0) {
+@@ -1214,6 +_,7 @@
+ 
+ 						break;
+ 					}
++				case -12:
+ 				case 12:
+ 				case 25:
+ 				case 27: {
 @@ -1264,6 +_,8 @@
  			int num = Main.superFastStack + 1;
  			Player localPlayer = Main.LocalPlayer;
@@ -226,6 +425,74 @@
  			}
  		}
  
+@@ -1342,6 +_,23 @@
+ 						if (inv == player.miscDyes)
+ 							num = 185 + slot;
+ 						break;
++					//TML Context: GamePad number magic aligned to match DemonHeart Accessory. 
++					//TML Note: There is no Master Mode Accessory slot code here for Gamepads.
++					case -10:
++					case -11:
++						int num3M = slot;
++						if (!LoaderManager.Get<AccessorySlotLoader>().ModdedIsAValidEquipmentSlotForIteration(slot, player))
++							num3M--;
++
++						num = 100 + num3M;
++						break;
++					case -12:
++						int num4M = slot;
++						if (!LoaderManager.Get<AccessorySlotLoader>().ModdedIsAValidEquipmentSlotForIteration(slot, player))
++							num4M--;
++
++						num = 120 + num4M;
++						break;
+ 					case 19:
+ 						num = 180;
+ 						break;
+@@ -1468,6 +_,11 @@
+ 					case 27:
+ 						value = TextureAssets.InventoryBack12.Value;
+ 						break;
++					case -10:
++					case -11:
++					case -12:
++						value = LoaderManager.Get<AccessorySlotLoader>().GetBackgroundTexture(slot, context);
++						break;
+ 					case 3:
+ 						value = TextureAssets.InventoryBack5.Value;
+ 						break;
+@@ -1588,6 +_,15 @@
+ 				case 27:
+ 					num10 = 1;
+ 					break;
++				case -10:
++					num10 = 11;
++					break;
++				case -11:
++					num10 = 2;
++					break;
++				case -12:
++					num10 = 1;
++					break;
+ 				case 16:
+ 					num10 = 4;
+ 					break;
+@@ -1610,7 +_,14 @@
+ 				Rectangle rectangle = value6.Frame(3, 6, num10 % 3, num10 / 3);
+ 				rectangle.Width -= 2;
+ 				rectangle.Height -= 2;
++
++				// Modded Accessory Slots
++				if (context == -10 || context == -11 || context == -12) {
++					LoaderManager.Get<AccessorySlotLoader>().DrawSlotTexture(value6, position + value.Size() / 2f * inventoryScale, rectangle, Color.White * 0.35f, 0f, rectangle.Size() / 2f, inventoryScale, SpriteEffects.None, 0f, slot, context);
++				}
++				else {
+-				spriteBatch.Draw(value6, position + value.Size() / 2f * inventoryScale, rectangle, Color.White * 0.35f, 0f, rectangle.Size() / 2f, inventoryScale, SpriteEffects.None, 0f);
++					spriteBatch.Draw(value6, position + value.Size() / 2f * inventoryScale, rectangle, Color.White * 0.35f, 0f, rectangle.Size() / 2f, inventoryScale, SpriteEffects.None, 0f);
++				}	
+ 			}
+ 
+ 			Vector2 vector = value.Size() * inventoryScale;
 @@ -1628,10 +_,15 @@
  				num11 *= inventoryScale;
  				Vector2 position2 = position + vector / 2f - rectangle2.Size() * num11 / 2f;
@@ -251,49 +518,73 @@
  					Vector2 position4 = position + value.Size() * inventoryScale / 2f - TextureAssets.Cd.Value.Size() * inventoryScale / 2f;
  					Color white = Color.White;
  					spriteBatch.Draw(TextureAssets.Cd.Value, position4, null, white, 0f, default(Vector2), num11, SpriteEffects.None, 0f);
-@@ -1901,7 +_,7 @@
- 					return false;
- 
- 				if (itemCollection[slot].wingSlot > 0 && item.wingSlot > 0)
--					return false;
-+					return !ItemLoader.CanEquipAccessory(item, slot);
+@@ -1861,7 +_,7 @@
+ 				inv[slot] = ArmorSwap(inv[slot], out success);
+ 				if (success) {
+ 					Main.EquipPageSelected = 0;
+-					AchievementsHelper.HandleOnEquip(player, item, item.accessory ? 10 : 8);
++					AchievementsHelper.HandleOnEquip(player, item, (item.accessory ? 10 : 8) * (context < 0 ? -1 : 1));
+ 				}
  			}
  
- 			for (int i = 0; i < itemCollection.Length; i++) {
-@@ -1917,7 +_,7 @@
- 					return true;
- 			}
- 
--			return false;
-+			return !ItemLoader.CanEquipAccessory(item, slot);
+@@ -1892,7 +_,9 @@
+ 			return true;
  		}
  
+-		private static bool AccCheck(Item[] itemCollection, Item item, int slot) {
++		internal static bool AccCheck(Item[] itemCollection, Item item, int slot) {
++			return AccCheck_Inner(itemCollection, item, slot);
++			/*
+ 			if (isEquipLocked(item.type))
+ 				return true;
+ 
+@@ -1918,8 +_,10 @@
+ 			}
+ 
+ 			return false;
++			*/
+ 		}
+ 
++		//TML: I (Solxan), have not been able to get this to ever run in-game. I suspect this code path is deprecated.
  		private static Item DyeSwap(Item item, out bool success) {
-@@ -1993,6 +_,14 @@
- 						accSlotToSwapTo = j - 3;
+ 			success = false;
+ 			if (item.dye <= 0)
+@@ -1934,9 +_,14 @@
  				}
+ 			}
  
-+				for (int k = 0; k < num2; k++) {
-+					int index = 3 + (accSlotToSwapTo + num2) % num2;
-+					if (ItemLoader.CanEquipAccessory(item, index)) {
-+						accSlotToSwapTo = index - 3;
-+						break;
-+					}
-+				}
+-			if (dyeSlotCount >= 10)
++			if (dyeSlotCount >= 10) {
++				item2 = ModSlotDyeSwap(item, out success);
++				if (success)
++					return item2;
 +
- 				if (accSlotToSwapTo > num2)
- 					return item;
+ 				dyeSlotCount = 0;
+-
++			}
++			
+ 			if (dyeSlotCount < 0)
+ 				dyeSlotCount = 9;
  
-@@ -2008,6 +_,9 @@
- 						num3 = k;
- 				}
- 
-+				if (!ItemLoader.CanEquipAccessory(item, num3))
-+					return item;
-+
+@@ -1974,6 +_,9 @@
+ 				player.armor[num + 2] = item.Clone();
+ 			}
+ 			else if (item.accessory) {
++				if (!AccessorySwap(player, item, ref result))
++					return result;
++				/*
+ 				int num2 = 3;
+ 				for (int i = 3; i < 10; i++) {
+ 					if (player.IsAValidEquipmentSlotForIteration(i)) {
+@@ -2011,6 +_,8 @@
  				result = player.armor[num3].Clone();
  				player.armor[num3] = item.Clone();
  				accSlotToSwapTo = 0;
++				*/
++				
+ 			}
+ 
+ 			SoundEngine.PlaySound(7);
 @@ -2105,7 +_,7 @@
  		}
  


### PR DESCRIPTION
* fixed DamageClass throwing an exception before the game can even start

if this gets undone heads are gonna fucking roll

* Adds static fields and values to make accessories and inventory dynamic.
Replaces many hardcoded numbers with equivalent fields
Can't open player screen properly. IsBugged

* Incomplete; realizing got carried away.
Gonna shelf this branch.

Branch has a mostly implemented dynamic accesory slots counting; meant to make adding accessory slots easier, but is getting out of hand, so gonna refocus in on original task.

* Revert "Merge pull request #10 from ThomasSpeedrunner/1.4_damageclassfix"

This reverts commit 808d7ebe68bdd01977140c0eb8e1f09518bc00f4, reversing
changes made to 1ab1050f1834076590a296017dc45be0e240c687.

* De-shelved. I think there is meaning here in making modded accessory slots actually clean.
Fixed a bunch of items; notably made vanilla saving be only vanilla slots again, as it should be.
Branch as is, is just a structural rework of vanilla naming that doesn't do anything.
PR now, or later?

* Finished testing that all vanilla movements, values, saving, loading work fine without modded slot being non-zero. Good start.

* 2 Issues to resolve for next commit:
1) in cases 9,11 in RightClickSpecial the swap is going wrong and upshifting by totalEquipSlots - vanillaEquipSlots. Funky
2) The armor vanity slots are not being saved in player.cs. Accesory vanities are being saved correctly, however.

* Calling this branch: Accessory Slot Creation Rework; Part 1: The Vanilla Twist.
Mostly implemented.
Remaining issues of unable to leftclick/shiftleftclick to place armor into vanity slot. Mostly because didn't deal with it yet.
Multiplayer is working wellish; draw issues with multiplayer exclusive UI draws such as team colours.

* De-rename several items:
1) demonheartUsed -> changed to masked
2) changed vanilla code to be commented out
3) changed CanAccessory to restore vanilla code, and then commented out for forwarders.

* Inbetween state push to keep content updating.
Adds abstract class ModAccessorySlot, as a tentative subclass of ModType. Moslty hardcode; doesn't do anything right now.
Also some minor cleanup in Main.cs.patch because of this.

* Pushing a stable version.
Doesn't do anything;
Need to add to ModAccessorySlot class:
1) an overridable method for custom conditions.
Need to add to Player.cs:
1) Full support for custom conditions
Need to add to Main.cs:
1) Complete the ModAccessorySlot Draw call.
Need to create an instance of ModAccessorySlot in exampleMod to test

* Need to pause for the day. Hit a roadblock
Current state: can launch and run as vanilla basically.
Current issues: functional except for the fact that player[myPlayer] in main does not account for post mod loading player data changes. So drawing doesn't work with mAccSlot and related loop.
Need to think about.

* In progress commit to bring branch up to date:
1) Began de-converting vanilla magic numbers
2) Moved equipment related hooks from ItemLoader to EquipLoader for consistency
3) Began to construct EquipLoader to handle ModAccessorySlots; slowly recreating vanilla methods as needed. All points of interest should be flagged by errors in current version.
4) Added ExampleMod exampleAccessorySlot file. Still have to work further before can flesh out.

* Small update to bring to a return to later state.

* Further cleaned up former vanilla changes.
Getting closer; remaining is to work on ModAccessorySlot, EquipLoader and related to work on draw functionality and multiplayer support.

* Added Draw functionality.
Remaining: Networking/MP and GamePad support.

* 'Basic' accessory slot functionality in singleplayer has been established.

2 known bugs of crashing on first load with change/ crashing on unload because I'm not being smart enough on handling nulls in Initialize().

Need to add Multiplayer netcode, and test thoroughly all virtuals in ModAccessorySlot and all functionality vectors.

* Further implemented multiplayer functionality; still need to do netcode, but it appears all functionality is there.

* Cleaned up a large amount of remnants from previous designs.
No new changes in this commit - all cleanup.

* Added: Basic functionality for scrollbars
Changed: Moved ModAccessorySlot to be its own subset of ModType to improve performance.

* Added rudimentary scrolling implementation

* Added multiplayer netcode, and cleaned up the UI a bit.
This branch is now presentable for review, sort of. Still concerned about how much code there is and refactoring it.

* Added multiplayer netcode, and cleaned up the UI a bit.
This branch is now presentable for review, sort of. Still concerned about how much code there is and refactoring it.

* Changed UI to have scrolling vanilla accessories. Looks cleaner.

* Minor cleanup item.

* Move scrollbar to right, and make slots per column calc dynamic.

* Final Cleanup Part 1 of 2

* Cleanup part 2 of 2: Cleanup Player.cs

* Uses PR #1312 now

* Update with tested version of UI scrollbar fix.

* Part 1 of 2: Address PR comments on organization.
Noted that some of the player Logic isn't quite right in terms of swapping, checking accessory conflicts, etc. Gonna need to take another look, suspect it is an ordering issue.

* Finish drafting up changes to ModAccessorySlot Redux

I believe the only thing outstanding now is  possibly documentation being out of date here and there, and an examplemod improvement.

* Cleanup absurd Patch by using GoTo

* Revert "Merge pull request #25 from Solxanich/tModLoader-1.4"

This reverts commit 2961a50f91d4ba686a31fa24b4754fcc68b61a63, reversing
changes made to d0d0cefd1e42177e55ed18c163da5870953336ce.

* Revert "Revert "Merge pull request #25 from Solxanich/tModLoader-1.4""

This reverts commit 9f4a328cd099b8738e88a9edcc7319e4627fe932.

* Update to 1.4.2.1

* Address patch errors.

Still need to look at https://github.com/tModLoader/tModLoader/pull/1370/files

* Update Player.cs.patch

* Fix bad merge result

* Manually Fix Patch Offsets being broken

* Fix Build Errors and Fresh Diff

* Cleanup a lot of code to meet my modern standards better

Still a lot TODO.
1) Fix bugs in Armor Swap for right click in inventory.
2) Display accessories in rendering on player selection screen
3) Multiplayer changes for unloaded slots, don't think the current unloaded slots will work in multiplayer too well
4) Cleanup in the Functionality code spread about AccessorySlotLoader and ItemSlot

* Draw code refactoring

* Add custom texture functionality

Remove ArmorSwap so that can rewrite it

* Fix Dye rendering and ArmorSwap

Just dealing with multiplayer & unloaded slots to go

* Finish point-testing multiplayer and patch

* Finalization of ExampleMod examples and testing

* Address all the easy to do feedback items

* Further Cleanup of duplicate code

 Getting closer to a ModPlayer implementation of the 4? functionality methods

* A rounds of testing & fixes

* ModPlayer Migration

* De-netcode Unloaded Slot

* Address Some feedback from discord for features

1. How can I make my slots enabled but not visible (they render with custom location, with a folding 'visibility toggle')
2. How to control swap order? (Wings should go in the wing slot slot when right clicked, before looking for other spaces in 'general slots'. Add this to the example?)

* Add SkipUIDraw to example mod instead of commenting out.

* Add Custom ApplyEquips support

* Resolve a few review comments

public-izing
Drop items on death
Better summaries
Renames
DrawCode design simplifications

* Add CanAccessoryBeEquippedWith() method

And add ItemLoader.CanEquipAccessory to several missing spots pertaining to left-click

* Fix a Netcode bug & Verify #1832 is fixed on this branch

* Make Draw more robust wrt EquipPages

* Fix Wing Vanity issue in UpdateVisibleAccessories

* Add ModItem hooks

* Fix bad logical in last commit

* Logical Simplification in CanAccessoryBeEquippedWith

* Fix ModAccessorySlotPlayer.Save/LoadData hooks after main branch merge

* Increase Robustness for multiple players

* Provide ModAccessorySlot.Player context during ModPlayer loading

* Partial support for mods hiding the default equip page.

* Fix DefenseCounter and Drawing of scrollbar

* Cache Itemslot.TML.cs Wing vanity/functional separation fix

* Fix Rendering order & Wings placement bug

* OnHover, HoverText Hooks; Vector2 position

* Switch CustomLocation to nullable Vector2

* Fix merge conflict in patch

* Remove unnecessary ItemLoader Hook

* Revert "Fix merge conflict in patch"

This reverts commit 3722405e3d47493d457e399b5cf30758cf60e054.

* Replace Context with AccessorySlotType

Also fix slot drawing when one is skipped,
cleaning up MusicLoader code,
Post/Pre draw hooks,
And a partial ItemSlotContext Enum for record keeping sake

* Add a more general implementation of static CurrentPlayer context

Co-authored-by: ThomasThePencil <tailsguy24@gmail.com>
Co-authored-by: nmoll <nmoll@NMOLLER-DESK>
Co-authored-by: Chicken-Bones <mehvids@gmail.com>

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
